### PR TITLE
Server fails to start in Ubuntu 18.04

### DIFF
--- a/tabpy-server/tabpy_server/startup.py
+++ b/tabpy-server/tabpy_server/startup.py
@@ -10,7 +10,7 @@ if sys.platform == 'win32':
     else:
         subprocess.Popen(['startup.bat'], cwd=dir_path)
 
-elif sys.platform in ['darwin', 'linux2']:
+elif sys.platform in ['darwin', 'linux2', 'linux']:
     if len(sys.argv) >= 2:
         subprocess.Popen(['sh', './startup.sh', sys.argv[1]])
     else:


### PR DESCRIPTION
Environment: Ubuntu 18.04 64 bit
Python 3.6
----
Steps to reproduce the error:
---
pip3 install tabpy-server
pip3 install tabpy-client
cd ~/.local/lib/python3.6/site-packages/tabpy_server
python3 startup.py
Operating system not recognized