### PR TITLE
fix typo and broken link in tabpy-tools docs

### DIFF
--- a/docs/tabpy-tools.md
+++ b/docs/tabpy-tools.md
@@ -231,7 +231,7 @@ have a Python API in `tabpy-tools`, only a raw [REST interface](server.md#httppo
 that other client bindings can easily implement. Tableau connects to TabPy
 using REST `Evaluate`.
 
-`Evaluate` allows calling a deployed endpoint from within the Python code block.
+`evaluate` allows calling a deployed endpoint from within the Python code block.
 The convention for this is to use a provided function call `tabpy.query` in the
 code, which behaves like the `query` method in `tabpy-tools`. See the
-[REST API documentation](server.md#rest-interfaces) for an example.
+[REST API documentation](server-rest.md) for an example.


### PR DESCRIPTION
server.md has been broken into separate files and this link needs to point to the REST docs