### PR TITLE
Update swagger config to parse new /info response schema.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 os: linux
 language: python
 python: 3.6
+env:
+   - TEST_ENV=true
 install:
-   - export TEST_ENV=true
    - ./startup.sh
    - pip install pytest
    - pip install pytest-cov

--- a/misc/TabPy.yml
+++ b/misc/TabPy.yml
@@ -182,6 +182,32 @@ definitions:
         type: string
       name:
         type: string
+      versions:
+        type: object
+        properties:
+          v1:
+            type: object
+            properties:
+              features:
+                type: object
+                properties:
+                  authentication:
+                    type: object
+                    properties:
+                      required:
+                        type: boolean
+                      methods:
+                        type: object
+                        properties:
+                          basic-auth:
+                            type: object
+                        required:
+                          - basic-auth
+                    required:
+                      - required
+                      - methods
+            required:
+              - features
   ErrorEvaluateScript500:
     type: object
     properties:


### PR DESCRIPTION
Testing done:
- In swagger editor, manually verified the response schema is correct + generates the correct model.
- Verified it can parse the response from a local instance of TabPy server from the dev branch.