### PR TITLE
add check for python version to be > 3.6.5

### DIFF
--- a/tabpy-server/setup.py
+++ b/tabpy-server/setup.py
@@ -3,6 +3,12 @@ try:
 except ImportError as err:
     print("Missing Python module requirement: setuptools.")
     raise err
+    
+import sys
+if sys.version_info < (3,6,5):
+    print("TabPy requires python version >= 3.6.5.  Detected")
+    print(sys.version)
+    raise Exception("Python Version Not Supported")
 
 from tabpy_server import __version__
 

--- a/tabpy-server/setup.py
+++ b/tabpy-server/setup.py
@@ -5,7 +5,7 @@ except ImportError as err:
     raise err
 
 import sys
-if sys.version_info < (3 , 6):
+if sys.version_info < (3, 6):
     print("TabPy requires python version >= 3.6.5.  Detected")
     print(sys.version)
     raise Exception("Python Version Not Supported")

--- a/tabpy-server/setup.py
+++ b/tabpy-server/setup.py
@@ -3,9 +3,9 @@ try:
 except ImportError as err:
     print("Missing Python module requirement: setuptools.")
     raise err
-    
+
 import sys
-if sys.version_info < (3,6,5):
+if sys.version_info < (3 , 6):
     print("TabPy requires python version >= 3.6.5.  Detected")
     print(sys.version)
     raise Exception("Python Version Not Supported")


### PR DESCRIPTION
setuptools apparently does not enforce this when installing.  Also, python_requires requires pip to be >9.0 and we don't have a check for that version.
add a check to ensure python is the minimal required version.  Leaving python_requires for now.