### PR TITLE
remove python_requires attribute

### DIFF
--- a/tabpy-server/setup.py
+++ b/tabpy-server/setup.py
@@ -8,7 +8,6 @@ from tabpy_server import __version__
 
 setup(
     name='tabpy-server',
-    python_requires='>=3.6.5',
     version=__version__,
     description='Web server Tableau uses to run Python scripts.',
     url='https://github.com/tableau/TabPy',


### PR DESCRIPTION
this attr is only used for pip installs and we will not support pip install any longer