### PR TITLE
add required packages to setup.py

### DIFF
--- a/tabpy-server/setup.py
+++ b/tabpy-server/setup.py
@@ -28,13 +28,27 @@ setup(
     package_data={'tabpy_server.static': ['*.*'],
                   'tabpy_server': ['startup.*', 'state.ini']},
     license='MIT',
+# Note: many of these required packages are included in base python
+# but are listed here because different linux distros use custom
+# python installations.  And users can remove packages at any point
     install_requires=[
+        'backports_abc',
+        'cloudpickle',
+        'configparser',
+        'decorator',
+        'future',
+        'genson',
+        'jsonschema~=2.3.0',
+        'mock',
+        'numpy',
         'pyopenssl',
         'python-dateutil',
         'requests',
         'simplejson',
+        'singledispatch',
         'six',
         'tornado==5.1.1',
         'Tornado-JSON',
+        'urllib3'
     ]
 )

--- a/tabpy-server/setup.py
+++ b/tabpy-server/setup.py
@@ -28,9 +28,9 @@ setup(
     package_data={'tabpy_server.static': ['*.*'],
                   'tabpy_server': ['startup.*', 'state.ini']},
     license='MIT',
-# Note: many of these required packages are included in base python
-# but are listed here because different linux distros use custom
-# python installations.  And users can remove packages at any point
+    # Note: many of these required packages are included in base python
+    # but are listed here because different linux distros use custom
+    # python installations.  And users can remove packages at any point
     install_requires=[
         'backports_abc',
         'cloudpickle',


### PR DESCRIPTION
Many of these packages are included in a typical base install of Python.  Testing has revealed that different linux distributions will customize python installs and omit one or more of these packages.  Add all known discrepancies uncovered during testing to setup.py and add a comment to this effect.