### PR TITLE
add test for mult entries

### DIFF
--- a/tabpy-server/server_tests/test_pwd_file.py
+++ b/tabpy-server/server_tests/test_pwd_file.py
@@ -103,7 +103,26 @@ class TestPasswordFile(unittest.TestCase):
             self.assertEqual('Failed to read password file {}'.format(
                 self.pwd_file.name), ex.args[0])
 
-    def test_given_one_login_many_times_in_pwd_file_expect_app_fails(self):
+    def test_given_duplicate_usernames_expect_parsing_fails(self):
+        self._set_file(self.config_file.name,
+                       "[TabPy]\n"
+                       "TABPY_PWD_FILE = {}".format(self.pwd_file.name))
+
+        login = 'user_name_123'
+        pwd = 'hashedpw'
+        self._set_file(self.pwd_file.name,
+                       "# passwords\n"
+                       "\n"
+                       "{} {}\n{} {}".format(login, pwd, login, pwd))
+
+        with self.assertRaises(RuntimeError) as cm:
+            app = TabPyApp(self.config_file.name)
+            ex = cm.exception
+            self.assertEqual('Failed to read password file {}'.format(
+                self.pwd_file.name), ex.args[0])
+
+
+    def test_given_one_line_with_too_many_params_in_pwd_file_expect_app_fails(self):
         self._set_file(self.config_file.name,
                        "[TabPy]\n"
                        "TABPY_PWD_FILE = {}".format(self.pwd_file.name))

--- a/tabpy-server/server_tests/test_pwd_file.py
+++ b/tabpy-server/server_tests/test_pwd_file.py
@@ -121,8 +121,7 @@ class TestPasswordFile(unittest.TestCase):
             self.assertEqual('Failed to read password file {}'.format(
                 self.pwd_file.name), ex.args[0])
 
-
-    def test_given_one_line_with_too_many_params_in_pwd_file_expect_app_fails(self):
+    def test_given_one_line_with_too_many_params_expect_app_fails(self):
         self._set_file(self.config_file.name,
                        "[TabPy]\n"
                        "TABPY_PWD_FILE = {}".format(self.pwd_file.name))


### PR DESCRIPTION
there was already a test for this condition but since it was missing a \n character it caused a different failure - too many arguments on a single line of the pwd file
change that test name to be more accurate and add a test for duplicate usernames
this is expected to hit 100% of app\util.py