### PR TITLE
Add logging to make auth state more clear

### DIFF
--- a/tabpy-server/tabpy_server/app/app.py
+++ b/tabpy-server/tabpy_server/app/app.py
@@ -240,7 +240,7 @@ class TabPyApp:
                               RuntimeError)
         else:
             logger.info(
-                "Password file is not specified: " + \
+                "Password file is not specified: "
                 "Authentication is not enabled")
 
         features = self._get_features()

--- a/tabpy-server/tabpy_server/app/app.py
+++ b/tabpy-server/tabpy_server/app/app.py
@@ -239,7 +239,7 @@ class TabPyApp:
                               self.settings[ConfigParameters.TABPY_PWD_FILE],
                               RuntimeError)
         else:
-            logger.info("Password file is not specified")
+            logger.info("Password file is not specified: Authentication is not enabled")
 
         features = self._get_features()
         self.settings['versions'] = {'v1': {'features': features}}

--- a/tabpy-server/tabpy_server/app/app.py
+++ b/tabpy-server/tabpy_server/app/app.py
@@ -239,7 +239,8 @@ class TabPyApp:
                               self.settings[ConfigParameters.TABPY_PWD_FILE],
                               RuntimeError)
         else:
-            logger.info("Password file is not specified: Authentication is not enabled")
+            logger.info(
+                "Password file is not specified: Authentication is not enabled")
 
         features = self._get_features()
         self.settings['versions'] = {'v1': {'features': features}}

--- a/tabpy-server/tabpy_server/app/app.py
+++ b/tabpy-server/tabpy_server/app/app.py
@@ -240,7 +240,8 @@ class TabPyApp:
                               RuntimeError)
         else:
             logger.info(
-                "Password file is not specified: Authentication is not enabled")
+                "Password file is not specified: " + \
+                "Authentication is not enabled")
 
         features = self._get_features()
         self.settings['versions'] = {'v1': {'features': features}}

--- a/tabpy-server/tabpy_server/app/util.py
+++ b/tabpy-server/tabpy_server/app/util.py
@@ -96,6 +96,6 @@ def parse_pwd_file(pwd_file_name):
                 logger.warning('Found username {} but no password'
                                .format(row[0]))
                 return False, {}
-            
+
     logger.info("Authentication is enabled")
     return True, credentials

--- a/tabpy-server/tabpy_server/app/util.py
+++ b/tabpy-server/tabpy_server/app/util.py
@@ -96,5 +96,6 @@ def parse_pwd_file(pwd_file_name):
                 logger.warning('Found username {} but no password'
                                .format(row[0]))
                 return False, {}
-
+            
+    logger.info("Authentication is enabled")
     return True, credentials


### PR DESCRIPTION
While debugging and starting/stopping server multiple times to toggle auth state I found it easier to just clearly log the auth state enabled or not enabled