### PR TITLE
add test to validate info response with auth off

### DIFF
--- a/tabpy-server/server_tests/test_service_info_handler.py
+++ b/tabpy-server/server_tests/test_service_info_handler.py
@@ -129,31 +129,31 @@ class TestServiceInfoHandlerWithoutAuth(AsyncHTTPTestCase):
 
         # create state.ini dir and file
         cls.state_dir = tempfile.mkdtemp(prefix=prefix)
-        with open(os.path.join(cls.state_dir, 'state.ini'), 'w+')
-            as cls.state_file:
+        with open(os.path.join(cls.state_dir, 'state.ini'), 'w+')\
+                as cls.state_file:
             cls.state_file.write('[Service Info]\n'
-                             'Name = TabPy Serve\n'
-                             'Description = \n'
-                             'Creation Time = 0\n'
-                             'Access-Control-Allow-Origin = \n'
-                             'Access-Control-Allow-Headers = \n'
-                             'Access-Control-Allow-Methods = \n'
-                             '\n'
-                             '[Query Objects Service Versions]\n'
-                             '\n'
-                             '[Query Objects Docstrings]\n'
-                             '\n'
-                             '[Meta]\n'
-                             'Revision Number = 1\n')
+                                 'Name = TabPy Serve\n'
+                                 'Description = \n'
+                                 'Creation Time = 0\n'
+                                 'Access-Control-Allow-Origin = \n'
+                                 'Access-Control-Allow-Headers = \n'
+                                 'Access-Control-Allow-Methods = \n'
+                                 '\n'
+                                 '[Query Objects Service Versions]\n'
+                                 '\n'
+                                 '[Query Objects Docstrings]\n'
+                                 '\n'
+                                 '[Meta]\n'
+                                 'Revision Number = 1\n')
         cls.state_file.close()
 
         # create config file
         cls.config_file = tempfile.NamedTemporaryFile(
             prefix=prefix, suffix='.conf', delete=False, mode='w+')
         cls.config_file.write(
-                '[TabPy]\n'
-                'TABPY_STATE_PATH = {}'.format(
-                    cls.state_dir))
+            '[TabPy]\n'
+            'TABPY_STATE_PATH = {}'.format(
+                cls.state_dir))
         cls.config_file.close()
 
     @classmethod

--- a/tabpy-server/server_tests/test_service_info_handler.py
+++ b/tabpy-server/server_tests/test_service_info_handler.py
@@ -129,7 +129,8 @@ class TestServiceInfoHandlerWithoutAuth(AsyncHTTPTestCase):
 
         # create state.ini dir and file
         cls.state_dir = tempfile.mkdtemp(prefix=prefix)
-        with open(os.path.join(cls.state_dir, 'state.ini'), 'w+') as cls.state_file:
+        with open(os.path.join(cls.state_dir, 'state.ini'), 'w+')
+            as cls.state_file:
             cls.state_file.write('[Service Info]\n'
                              'Name = TabPy Serve\n'
                              'Description = \n'

--- a/tabpy-server/server_tests/test_service_info_handler.py
+++ b/tabpy-server/server_tests/test_service_info_handler.py
@@ -150,11 +150,9 @@ class TestServiceInfoHandlerWithoutAuth(AsyncHTTPTestCase):
         cls.config_file = tempfile.NamedTemporaryFile(
             prefix=prefix, suffix='.conf', delete=False)
         cls.config_file.write(
-            bytes(
                 '[TabPy]\n'
                 'TABPY_STATE_PATH = {}'.format(
-                    cls.state_dir),
-                'utf-8'))
+                    cls.state_dir))
         cls.config_file.close()
         cls.config_file.close()
 

--- a/tabpy-server/server_tests/test_service_info_handler.py
+++ b/tabpy-server/server_tests/test_service_info_handler.py
@@ -129,8 +129,8 @@ class TestServiceInfoHandlerWithoutAuth(AsyncHTTPTestCase):
 
         # create state.ini dir and file
         cls.state_dir = tempfile.mkdtemp(prefix=prefix)
-        cls.state_file = open(os.path.join(cls.state_dir, 'state.ini'), 'w+')
-        cls.state_file.write('[Service Info]\n'
+        with open(os.path.join(cls.state_dir, 'state.ini'), 'w+') as cls.state_file:
+            cls.state_file.write('[Service Info]\n'
                              'Name = TabPy Serve\n'
                              'Description = \n'
                              'Creation Time = 0\n'
@@ -148,14 +148,11 @@ class TestServiceInfoHandlerWithoutAuth(AsyncHTTPTestCase):
 
         # create config file
         cls.config_file = tempfile.NamedTemporaryFile(
-            prefix=prefix, suffix='.conf', delete=False)
+            prefix=prefix, suffix='.conf', delete=False, mode='w+')
         cls.config_file.write(
-            bytes(
                 '[TabPy]\n'
                 'TABPY_STATE_PATH = {}'.format(
-                    cls.state_dir),
-            'utf-8'))
-        cls.config_file.close()
+                    cls.state_dir))
         cls.config_file.close()
 
     @classmethod

--- a/tabpy-server/server_tests/test_service_info_handler.py
+++ b/tabpy-server/server_tests/test_service_info_handler.py
@@ -150,9 +150,11 @@ class TestServiceInfoHandlerWithoutAuth(AsyncHTTPTestCase):
         cls.config_file = tempfile.NamedTemporaryFile(
             prefix=prefix, suffix='.conf', delete=False)
         cls.config_file.write(
+            bytes(
                 '[TabPy]\n'
                 'TABPY_STATE_PATH = {}'.format(
-                    cls.state_dir))
+                    cls.state_dir),
+            'utf-8'))
         cls.config_file.close()
         cls.config_file.close()
 

--- a/tabpy-server/server_tests/test_service_info_handler.py
+++ b/tabpy-server/server_tests/test_service_info_handler.py
@@ -120,3 +120,66 @@ class TestServiceInfoHandlerWithAuth(AsyncHTTPTestCase):
                 'required': True,
             }
         }, features)
+
+
+class TestServiceInfoHandlerWithoutAuth(AsyncHTTPTestCase):
+    @classmethod
+    def setUpClass(cls):
+        prefix = '__TestServiceInfoHandlerWithoutAuth_'
+
+        # create state.ini dir and file
+        cls.state_dir = tempfile.mkdtemp(prefix=prefix)
+        cls.state_file = open(os.path.join(cls.state_dir, 'state.ini'), 'w+')
+        cls.state_file.write('[Service Info]\n'
+                             'Name = TabPy Serve\n'
+                             'Description = \n'
+                             'Creation Time = 0\n'
+                             'Access-Control-Allow-Origin = \n'
+                             'Access-Control-Allow-Headers = \n'
+                             'Access-Control-Allow-Methods = \n'
+                             '\n'
+                             '[Query Objects Service Versions]\n'
+                             '\n'
+                             '[Query Objects Docstrings]\n'
+                             '\n'
+                             '[Meta]\n'
+                             'Revision Number = 1\n')
+        cls.state_file.close()
+
+        # create config file
+        cls.config_file = tempfile.NamedTemporaryFile(
+            prefix=prefix, suffix='.conf', delete=False)
+        cls.config_file.write(
+            bytes(
+                '[TabPy]\n'
+                'TABPY_STATE_PATH = {}'.format(
+                    cls.state_dir),
+                'utf-8'))
+        cls.config_file.close()
+        cls.config_file.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(cls.state_file.name)
+        os.remove(cls.config_file.name)
+        os.rmdir(cls.state_dir)
+
+    def get_app(self):
+        self.app = TabPyApp(self.config_file.name)
+        return self.app._create_tornado_web_app()
+
+    def test_given_tabpy_server_with_no_auth_expect_correct_info_response(self):
+        response = self.fetch('/info')
+        self.assertEqual(response.code, 200)
+        actual_response = json.loads(response.body)
+        expected_response = _create_expected_info_response(
+            self.app.settings, self.app.tabpy_state)
+
+        self.assertDictEqual(actual_response, expected_response)
+        self.assertTrue('versions' in actual_response)
+        versions = actual_response['versions']
+        self.assertTrue('v1' in versions)
+        v1 = versions['v1']
+        self.assertTrue('features' in v1)
+        features = v1['features']
+        self.assertDictEqual({}, features)

--- a/tabpy-server/server_tests/test_service_info_handler.py
+++ b/tabpy-server/server_tests/test_service_info_handler.py
@@ -168,7 +168,7 @@ class TestServiceInfoHandlerWithoutAuth(AsyncHTTPTestCase):
         self.app = TabPyApp(self.config_file.name)
         return self.app._create_tornado_web_app()
 
-    def test_given_tabpy_server_with_no_auth_expect_correct_info_response(self):
+    def test_tabpy_server_with_no_auth_expect_correct_info_response(self):
         response = self.fetch('/info')
         self.assertEqual(response.code, 200)
         actual_response = json.loads(response.body)


### PR DESCRIPTION
since this actually goes through tornado this should be sufficient for E2E to validate the info response for auth on (already tested) and auth off (this test)