### PR TITLE
Fix for paths with spaces

### DIFF
--- a/docs/TableauConfiguration.md
+++ b/docs/TableauConfiguration.md
@@ -33,12 +33,12 @@ In Tableau Desktop version 10.1 or later:
 To configure Tableau Server 2018.2 and newer versions to connect to TabPy server
 use [TSM command line tool](https://onlinehelp.tableau.com/current/server/en-us/tsm.htm).
 
-To configure a non secure connection to TabPy server set `vizqlserver.extsvc.host`
-and `vizqlserver.extsvc.port` parameters:
+To configure a non secure connection to TabPy server configuration:
 
 ```sh
-tsm set vizqlserver.extsvc.host <ip address or host name of the machine hosting TabPy>
-tsm set vizqlserver.extsvc.port <port for TabPy>
+tsm configuration set -k vizqlserver.extsvc.host -v <ip address or hostname>
+tsm configuration set -k vizqlserver.extsvc.port -v <port or TabPy>
+tsm pending-changes apply
 ```
 
 To configure a secure connection to TabPy server use `tsm security vizql-extsvc enable`

--- a/startup.cmd
+++ b/startup.cmd
@@ -71,4 +71,3 @@ GOTO:END
     CD "%TABPY_ROOT%"
     EXIT /B %RET%
     ENDLOCAL
-

--- a/startup.cmd
+++ b/startup.cmd
@@ -3,8 +3,8 @@ SETLOCAL
 
 
 REM Set environment variables.
-SET TABPY_ROOT=%CD%
-SET INSTALL_LOG=%TABPY_ROOT%\tabpy-server\install.log
+SET "TABPY_ROOT=%CD%"
+SET "INSTALL_LOG=%TABPY_ROOT%\tabpy-server\install.log"
 SET SAVE_PYTHONPATH=%PYTHONPATH%
 
 
@@ -19,21 +19,19 @@ IF %ERRORLEVEL% NEQ 0 (
 REM Install requirements using Python setup tools.
 ECHO Installing any missing dependencies...
 
-CD %TABPY_ROOT%\tabpy-server
-ECHO Installing tabpy-server dependencies...>%INSTALL_LOG%	
-python setup.py install>>%INSTALL_LOG% 2>&1
+CD "%TABPY_ROOT%\tabpy-server"
+ECHO Installing tabpy-server dependencies...>"%INSTALL_LOG%"	
+python setup.py install>>"%INSTALL_LOG%" 2>&1
 
-CD %TABPY_ROOT%\tabpy-tools
-ECHO: >> %INSTALL_LOG%
-ECHO Installing tabpy-tools dependencies...>>%INSTALL_LOG%
-python setup.py install>>%INSTALL_LOG% 2>&1
+CD "%TABPY_ROOT%\tabpy-tools"
+ECHO: >> "%INSTALL_LOG%"
+ECHO Installing tabpy-tools dependencies...>>"%INSTALL_LOG%"
+python setup.py install>>"%INSTALL_LOG%" 2>&1
 
-CD %TABPY_ROOT%
+CD "%TABPY_ROOT%"
 SET INSTALL_LOG_MESSAGE=    Check %INSTALL_LOG% for details.
 IF %ERRORLEVEL% NEQ 0 (
-    IF %CD% NEQ %TABPY_ROOT% (
-        CD %TABPY_ROOT%
-    )
+    CD "%TABPY_ROOT%"
     ECHO     failed
     ECHO %INSTALL_LOG_MESSAGE%
     SET RET=1
@@ -46,7 +44,7 @@ IF %ERRORLEVEL% NEQ 0 (
 
 REM Parse optional CLI arguments: config file
 ECHO Parsing parameters...
-SET PYTHONPATH=%TABPY_ROOT%\tabpy-server;%TABPY_ROOT%\tabpy-tools;%PYTHONPATH%
+SET PYTHONPATH="%TABPY_ROOT%\tabpy-server;%TABPY_ROOT%\tabpy-tools;%PYTHONPATH%"
 SET STARTUP_CMD=python tabpy-server\tabpy_server\tabpy.py
 IF [%1] NEQ [] (
     ECHO     Using config file at %1
@@ -70,7 +68,7 @@ GOTO:END
 
 :END
     SET PYTHONPATH=%SAVE_PYTHONPATH%
-    CD %TABPY_ROOT%
+    CD "%TABPY_ROOT%"
     EXIT /B %RET%
     ENDLOCAL
 

--- a/startup.sh
+++ b/startup.sh
@@ -16,8 +16,8 @@ function install_dependencies() {
         echo -e "\nInstalling ${1} dependencies..."
         python3 setup.py install
     elif [ "$2" = false ]; then
-        echo -e "\nInstalling ${1} dependencies..." >> ${3}
-        python3 setup.py install >> ${3} 2>&1
+        echo -e "\nInstalling ${1} dependencies..." >> "${3}"
+        python3 setup.py install >> "${3}" 2>&1
     else
         echo Invalid startup environment.
         exit 1
@@ -32,9 +32,9 @@ check_status "Cannot find Python.  Check that Python is installed and is in the 
 
 # Setting local variables
 echo Setting TABPY_ROOT to current working directory.
-TABPY_ROOT=$PWD
-INSTALL_LOG=${TABPY_ROOT}/tabpy-server/install.log
-echo "" > ${INSTALL_LOG}
+TABPY_ROOT="$PWD"
+INSTALL_LOG="${TABPY_ROOT}/tabpy-server/install.log"
+echo "" > "${INSTALL_LOG}"
 PRINT_INSTALL_LOGS=false
 
 # Parse CLI parameters
@@ -64,13 +64,13 @@ if [ "$PRINT_INSTALL_LOGS" = false ]; then
     echo Read the logs at ${INSTALL_LOG}
 fi
 
-cd ${TABPY_ROOT}/tabpy-server
+cd "${TABPY_ROOT}/tabpy-server"
 install_dependencies "tabpy-server" ${PRINT_INSTALL_LOGS} ${INSTALL_LOG}
 
-cd ${TABPY_ROOT}/tabpy-tools
+cd "${TABPY_ROOT}/tabpy-tools"
 install_dependencies "tabpy-tools" ${PRINT_INSTALL_LOGS} ${INSTALL_LOG}
 
-cd ${TABPY_ROOT}
+cd "${TABPY_ROOT}"
 check_status
 
 if [ ! -z ${CONFIG} ]; then
@@ -87,7 +87,7 @@ fi
 echo
 echo Starting TabPy server...
 SAVE_PYTHONPATH=$PYTHONPATH
-export PYTHONPATH=${TABPY_ROOT}/tabpy-server:${TABPY_ROOT}/tabpy-tools:$PYTHONPATH
+export PYTHONPATH="${TABPY_ROOT}/tabpy-server:${TABPY_ROOT}/tabpy-tools:$PYTHONPATH"
 if [ -z $CONFIG ]; then
     echo Using default parameters.
     python3 tabpy-server/tabpy_server/tabpy.py

--- a/startup.sh
+++ b/startup.sh
@@ -22,7 +22,7 @@ function install_dependencies() {
         echo Invalid startup environment.
         exit 1
     fi
-    check_status
+    check_status "Cannot install dependecies."
 }
 
 # Check for Python in PATH


### PR DESCRIPTION
Updated startup scripts for when there are spaces in the path where TabPy is running from.