### PR TITLE
Add a warning when python version is below 3.6.5

### DIFF
--- a/startup.cmd
+++ b/startup.cmd
@@ -11,7 +11,7 @@ SET SAVE_PYTHONPATH=%PYTHONPATH%
 ECHO Checking for presence of Python in the system path variable.
 python --version
 IF %ERRORLEVEL% NEQ 0 (
-    ECHO     Cannot find Python.exe.  Check that Python is installed and is in the system PATH environment variable.
+    ECHO Cannot find Python.exe. Check that Python 3.6.5 or higher is installed and is in the system PATH environment variable.
     SET RET=1
     GOTO:END
 ) ELSE (

--- a/startup.cmd
+++ b/startup.cmd
@@ -14,6 +14,14 @@ IF %ERRORLEVEL% NEQ 0 (
     ECHO     Cannot find Python.exe.  Check that Python is installed and is in the system PATH environment variable.
     SET RET=1
     GOTO:END
+) ELSE (
+    FOR /F "TOKENS=2" %%a IN ('python --version') DO (
+        IF %%a LSS 3.6.5 (
+            ECHO Python 3.6.5 or higher is needed.
+            SET RET=1
+            GOTO:END
+        )
+    )
 )
 
 REM Install requirements using Python setup tools.


### PR DESCRIPTION
A fix for bug
[TabPy] we don't warn user if using python 2.7x that tabpy will fail to start

