### PR TITLE
Print a warning/error if python version is not as required

### DIFF
--- a/startup.cmd
+++ b/startup.cmd
@@ -24,7 +24,7 @@ IF %ERRORLEVEL% NEQ 0 (
             SET RET=1
             GOTO:END
         ) ELSE IF %%a LSS %DESIRED_PY_VER% (
-            ECHO Important Warning : Python %%a% is not supported. Please upgrade Python to 3.6.5 or higher.
+            ECHO Warning : Python %%a% is not supported. Please upgrade Python to 3.6.5 or higher.
             SET RET=1
         )
     )

--- a/startup.cmd
+++ b/startup.cmd
@@ -6,10 +6,12 @@ REM Set environment variables.
 SET TABPY_ROOT="%CD%"
 SET INSTALL_LOG=%TABPY_ROOT%\tabpy-server\install.log
 SET SAVE_PYTHONPATH=%PYTHONPATH%
+SET MIN_PY_VER=3.6
+SET DESIRED_PY_VER=3.6.5
 
 
 ECHO Checking for presence of Python in the system path variable.
-SET PYTHON_ERROR=TabPy startup failed. Check that Python 3.6.5 or higher is installed and is in the system PATH environment variable.
+SET PYTHON_ERROR=Fatal Error : TabPy startup failed. Check that Python 3.6.5 or higher is installed and is in the system PATH environment variable.
 python --version
 IF %ERRORLEVEL% NEQ 0 (
     ECHO %PYTHON_ERROR%
@@ -17,10 +19,13 @@ IF %ERRORLEVEL% NEQ 0 (
     GOTO:END
 ) ELSE (
     FOR /F "TOKENS=2" %%a IN ('python --version 2^>^&1') DO (
-        IF %%a LSS 3.6.5 (
+        IF %%a LSS %MIN_PY_VER% (
             ECHO %PYTHON_ERROR%
             SET RET=1
             GOTO:END
+        ) ELSE IF %%a LSS %DESIRED_PY_VER% (
+            ECHO Important Warning : Python %%a% is not supported. Please upgrade Python to 3.6.5 or higher.
+            SET RET=1
         )
     )
 )

--- a/startup.cmd
+++ b/startup.cmd
@@ -9,11 +9,20 @@ SET SAVE_PYTHONPATH=%PYTHONPATH%
 
 
 ECHO Checking for presence of Python in the system path variable.
+SET PYTHON_ERROR=TabPy startup failed. Check that Python 3.6.5 or higher is installed and is in the system PATH environment variable.
 python --version
 IF %ERRORLEVEL% NEQ 0 (
-    ECHO     Cannot find Python.exe.  Check that Python is installed and is in the system PATH environment variable.
+    ECHO %PYTHON_ERROR%
     SET RET=1
     GOTO:END
+) ELSE (
+    FOR /F "TOKENS=2" %%a IN ('python --version 2^>^&1') DO (
+        IF %%a LSS 3.6.5 (
+            ECHO %PYTHON_ERROR%
+            SET RET=1
+            GOTO:END
+        )
+    )
 )
 
 REM Install requirements using Python setup tools.

--- a/startup.sh
+++ b/startup.sh
@@ -19,7 +19,7 @@ function check_python_version() {
         echo Fatal Error : $1
         exit 1
     elif [ "${py_ver[1]}" \< "$desired_py_ver" ]; then
-        echo Important Warning : Python ${py_ver[1]} is not supported. Please upgrade Python to 3.6.5 or higher.
+        echo Warning : Python ${py_ver[1]} is not supported. Please upgrade Python to 3.6.5 or higher.
     fi
 }
 

--- a/startup.sh
+++ b/startup.sh
@@ -15,7 +15,7 @@ function check_python_version() {
     check_status $1
 
     py_ver=($(python3 --version 2>&1) \| tr ' ' ' ')
-    if [ "${py_ver[1]}" \< "min_py_ver" ]; then
+    if [ "${py_ver[1]}" \< "$min_py_ver" ]; then
         echo Fatal Error : $1
         exit 1
     elif [ "${py_ver[1]}" \< "$desired_py_ver" ]; then

--- a/startup.sh
+++ b/startup.sh
@@ -2,7 +2,19 @@
 
 function check_status() {
     if [ $? -ne 0 ]; then
-        echo TabPy startup failed. $1
+        echo $1
+        exit 1
+    fi
+}
+
+function check_python_version() {
+    python3 --version
+    check_status $1
+
+    desired_py_ver=3.6.5
+    py_ver=($(python3 --version 2>&1) \| tr ' ' ' ')
+    if [ "${py_ver[1]}" \< "$desired_py_ver" ]; then
+        echo $1
         exit 1
     fi
 }
@@ -27,8 +39,7 @@ function install_dependencies() {
 
 # Check for Python in PATH
 echo Checking for presence of Python in the system path variable.
-python3 --version
-check_status "Cannot find Python.  Check that Python is installed and is in the system PATH environment variable."
+check_python_version "TabPy startup failed. Check that Python 3.6.5 or higher is installed and is in the system PATH environment variable."
 
 # Setting local variables
 echo Setting TABPY_ROOT to current working directory.

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+min_py_ver=3.6
+desired_py_ver=3.6.5
+
 function check_status() {
     if [ $? -ne 0 ]; then
         echo $1
@@ -11,11 +14,12 @@ function check_python_version() {
     python3 --version
     check_status $1
 
-    desired_py_ver=3.6.5
     py_ver=($(python3 --version 2>&1) \| tr ' ' ' ')
-    if [ "${py_ver[1]}" \< "$desired_py_ver" ]; then
-        echo $1
+    if [ "${py_ver[1]}" \< "min_py_ver" ]; then
+        echo Fatal Error : $1
         exit 1
+    elif [ "${py_ver[1]}" \< "$desired_py_ver" ]; then
+        echo Important Warning : Python ${py_ver[1]} is not supported. Please upgrade Python to 3.6.5 or higher.
     fi
 }
 
@@ -34,7 +38,7 @@ function install_dependencies() {
         echo Invalid startup environment.
         exit 1
     fi
-    check_status "Cannot install dependecies."
+    check_status "Cannot install dependencies."
 }
 
 # Check for Python in PATH


### PR DESCRIPTION
Change: 
If python version is below 3.6, print an error to console, and block the start up, since it won't success anyway.
If python version is below 3.6.5, print a warning to console, without blocking the start up.

Related Task: 
https://tfs.tsi.lan/tfs/DefaultCollection/Tableau-Dev/Advanced%20Analytics%20-%20(Augmented%20Analytics%20Area)/_workitems?id=913569&triage=true&_a=edit