### PR TITLE
Restoring overwritten test

### DIFF
--- a/tests/integration/test_deploy_model_ssl_off_auth_off.py
+++ b/tests/integration/test_deploy_model_ssl_off_auth_off.py
@@ -8,15 +8,13 @@ class TestDeployModelSSLOffAuthOff(integ_test_base.IntegTestBase):
         path = str(Path('models', 'setup.py'))
         subprocess.call([self.py, path, self._get_config_file_name()])
 
-        payload = (
-            '''{
-                "data": { "_arg1": ["happy", "sad", "neutral"] },
-                "script":
-                "return tabpy.query('Sentiment Analysis',_arg1)['response']"
-            }''')
-
         conn = self._get_connection()
-        conn.request("POST", "/evaluate", payload)
-        SentimentAnalysis_eval = conn.getresponse()
-        self.assertEqual(200, SentimentAnalysis_eval.status)
-        SentimentAnalysis_eval.read()
+        conn.request("GET", "/endpoints/PCA")
+        PCA_request = conn.getresponse()
+        self.assertEqual(200, PCA_request.status)
+        PCA_request.read()
+
+        conn.request("GET", "/endpoints/Sentiment%20Analysis")
+        SentimentAnalysis_request = conn.getresponse()
+        self.assertEqual(200, SentimentAnalysis_request.status)
+        SentimentAnalysis_request.read()


### PR DESCRIPTION
When writing the new integration test for models (test_deploy_and_evaluate_model.py) I accidentally overwrote an existing test (test_deploy_model_ssl_off_auth_off.py), reverting this test back.