### PR TITLE
fixing regex issue where . were not allowed in endpoint path

### DIFF
--- a/tabpy-server/tabpy_server/handlers/management_handler.py
+++ b/tabpy-server/tabpy_server/handlers/management_handler.py
@@ -94,7 +94,7 @@ class ManagementHandler(MainHandler):
                 self.settings[SettingsParameters.StateFilePath], name, version)
             self.logger.log(logging.DEBUG,
                             f'Checking source path {src_path}...')
-            _path_checker = _compile(r'^[\\\:a-zA-Z0-9-_~\s/]+$')
+            _path_checker = _compile(r'^[\\\:a-zA-Z0-9-_~\s/\.]+$')
             # copy from staging
             if src_path:
                 if not isinstance(request_data['src_path'], str):


### PR DESCRIPTION
the ednpoint path no longer allowed for periods and tabpy releases contain them (ex - TabPy-0.6) so model deployment was failing