### PR TITLE
Fix models call via /evaluate in HTTPS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,11 +12,11 @@
     "python.linting.flake8Enabled": false,
     "python.linting.enabled": true,
     "python.testing.autoTestDiscoverOnSaveEnabled": true,
-    "python.testing.pyTestArgs": [
-        "tests"
+    "python.testing.pytestArgs": [
+        "."
     ],
-    "python.testing.unittestEnabled": true,
+    "python.testing.unittestEnabled": false,
     "python.testing.nosetestsEnabled": false,
-    "python.testing.pyTestEnabled": true,
+    "python.testing.pytestEnabled": true,
     "python.linting.pep8Enabled": true
 }

--- a/tabpy-server/tabpy_server/app/app.py
+++ b/tabpy-server/tabpy_server/app/app.py
@@ -173,27 +173,45 @@ class TabPyApp:
                           default_val=None,
                           check_env_var=False):
             if config_key is not None and\
+               parser.has_section('TabPy') and\
                parser.has_option('TabPy', config_key):
                 self.settings[settings_key] = parser.get('TabPy', config_key)
+                logger.debug(
+                    f'Parameter {settings_key} set to '
+                    f'"{self.settings[settings_key]}" '
+                    'from config file')
             elif check_env_var:
                 self.settings[settings_key] = os.getenv(
                     config_key, default_val)
+                logger.debug(
+                    f'Parameter {settings_key} set to '
+                    f'"{self.settings[settings_key]}" '
+                    'from environment variable')
             elif default_val is not None:
                 self.settings[settings_key] = default_val
+                logger.debug(
+                    f'Parameter {settings_key} set to '
+                    f'"{self.settings[settings_key]}" '
+                    'from default value')
+            else:
+                logger.debug(
+                    f'Parameter {settings_key} is not set')
 
         set_parameter(SettingsParameters.Port, ConfigParameters.TABPY_PORT,
                       default_val=9004, check_env_var=True)
         set_parameter(SettingsParameters.ServerVersion, None,
                       default_val=__version__)
 
-        set_parameter(SettingsParameters.EvaluateTimeout, ConfigParameters.TABPY_EVALUATE_TIMEOUT,
+        set_parameter(SettingsParameters.EvaluateTimeout,
+                      ConfigParameters.TABPY_EVALUATE_TIMEOUT,
                       default_val=30)
         try:
             self.settings[SettingsParameters.EvaluateTimeout] = float(
                 self.settings[SettingsParameters.EvaluateTimeout])
         except ValueError:
             logger.warning(
-                'Evaluate timeout must be a float type. Defaulting to evaluate timeout of 30 seconds.')
+                'Evaluate timeout must be a float type. Defaulting '
+                'to evaluate timeout of 30 seconds.')
             self.settings[SettingsParameters.EvaluateTimeout] = 30
 
         set_parameter(SettingsParameters.UploadDir,

--- a/tabpy-server/tabpy_server/handlers/base_handler.py
+++ b/tabpy-server/tabpy_server/handlers/base_handler.py
@@ -125,6 +125,7 @@ class BaseHandler(tornado.web.RequestHandler):
         self.tabpy_state = app.tabpy_state
         # set content type to application/json
         self.set_header("Content-Type", "application/json")
+        self.protocol = self.settings[SettingsParameters.TransferProtocol]
         self.port = self.settings[SettingsParameters.Port]
         self.python_service = app.python_service
         self.credentials = app.credentials

--- a/tabpy-server/tabpy_server/state.ini
+++ b/tabpy-server/tabpy_server/state.ini
@@ -7,11 +7,8 @@ Access-Control-Allow-Headers =
 Access-Control-Allow-Methods = 
 
 [Query Objects Service Versions]
-f1 = {"description": "f1", "type": "model", "version": 1, "dependencies": [], "target": null, "creation_time": 1563294707, "last_modified_time": 1563294707, "schema": null}
 
 [Query Objects Docstrings]
-f1 = -- no docstring found in query function --
 
 [Meta]
-Revision Number = 2
-
+Revision Number = 1

--- a/tabpy-server/tabpy_server/state.ini
+++ b/tabpy-server/tabpy_server/state.ini
@@ -7,8 +7,11 @@ Access-Control-Allow-Headers =
 Access-Control-Allow-Methods = 
 
 [Query Objects Service Versions]
+f1 = {"description": "f1", "type": "model", "version": 1, "dependencies": [], "target": null, "creation_time": 1563294707, "last_modified_time": 1563294707, "schema": null}
 
 [Query Objects Docstrings]
+f1 = -- no docstring found in query function --
 
 [Meta]
-Revision Number = 1
+Revision Number = 2
+

--- a/tests/integration/integ_test_base.py
+++ b/tests/integration/integ_test_base.py
@@ -141,13 +141,15 @@ class IntegTestBase(unittest.TestCase):
     def _get_evaluate_timeout(self) -> str:
         '''
         Returns the configured timeout for the /evaluate method.
-        Default implementation returns None, which means that the timeout will default to 30.
+        Default implementation returns None, which means that
+        the timeout will default to 30.
 
         Returns
         -------
         str
             Timeout for calling /evaluate.
-            If None, defaults TABPY_EVALUATE_TIMEOUT setting will default to '30'.
+            If None, defaults TABPY_EVALUATE_TIMEOUT setting
+            will default to '30'.
         '''
         return None
 

--- a/tests/integration/test_deploy_and_evaluate_model_ssl.py
+++ b/tests/integration/test_deploy_and_evaluate_model_ssl.py
@@ -1,0 +1,41 @@
+import integ_test_base
+import requests
+import subprocess
+from pathlib import Path
+
+
+class TestDeployAndEvaluateModelSSL(integ_test_base.IntegTestBase):
+    def _get_port(self):
+        return '9005'
+
+    def _get_transfer_protocol(self) -> str:
+        return 'https'
+
+    def _get_certificate_file_name(self) -> str:
+        return './tests/integration/resources/2019_04_24_to_3018_08_25.crt'
+
+    def _get_key_file_name(self) -> str:
+        return './tests/integration/resources/2019_04_24_to_3018_08_25.key'
+
+    def test_deploy_and_evaluate_model_ssl(self):
+        path = str(Path('models', 'setup.py'))
+        subprocess.call([self.py, path, self._get_config_file_name()])
+
+        payload = (
+            '''{
+                "data": { "_arg1": ["happy", "sad", "neutral"] },
+                "script":
+                "return tabpy.query('Sentiment%20Analysis',_arg1)['response']"
+            }''')
+
+        session = requests.Session()
+        # Do not verify servers' cert to be signed by trusted CA
+        session.verify = False
+        # Do not warn about insecure request
+        requests.packages.urllib3.disable_warnings()
+        response = session.post(
+            f'{self._get_transfer_protocol()}://'
+            f'localhost:{self._get_port()}/evaluate',
+            data=payload)
+
+        self.assertEqual(200, response.status_code)

--- a/tests/unit/server_tests/test_config.py
+++ b/tests/unit/server_tests/test_config.py
@@ -108,7 +108,9 @@ class TestPartialConfigFile(unittest.TestCase):
     @patch('tabpy_server.app.app.os.path.exists', return_value=True)
     @patch('tabpy_server.app.app._get_state_from_file')
     @patch('tabpy_server.app.app.TabPyState')
-    def test_custom_evaluate_timeout_valid(self, mock_state, mock_get_state_from_file, mock_path_exists):
+    def test_custom_evaluate_timeout_valid(self, mock_state,
+                                           mock_get_state_from_file,
+                                           mock_path_exists):
         self.assertTrue(self.config_file is not None)
         config_file = self.config_file
         config_file.write('[TabPy]\n'
@@ -121,7 +123,9 @@ class TestPartialConfigFile(unittest.TestCase):
     @patch('tabpy_server.app.app.os.path.exists', return_value=True)
     @patch('tabpy_server.app.app._get_state_from_file')
     @patch('tabpy_server.app.app.TabPyState')
-    def test_custom_evaluate_timeout_invalid(self, mock_state, mock_get_state_from_file, mock_path_exists):
+    def test_custom_evaluate_timeout_invalid(self, mock_state,
+                                             mock_get_state_from_file,
+                                             mock_path_exists):
         self.assertTrue(self.config_file is not None)
         config_file = self.config_file
         config_file.write('[TabPy]\n'


### PR DESCRIPTION
* In HTTPS mode models called with /evaluate will be invoked with correct URL (starting with https://)
* Added integration test for the case
* Fixed some styling