### PR TITLE
fix broken link in server-config.md

### DIFF
--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -71,7 +71,7 @@ at [`logging.config` documentation page](https://docs.python.org/3.6/library/log
   section. Default value - not set.
 - `TABPY_TRANSFER_PROTOCOL` - transfer protocol. Default value - `http`. If
   set to `https` two additional parameters have to be specified:
-  `TABPY_CERTIFICATE_FILE` and `TABPY_KEY_FILE`. 
+  `TABPY_CERTIFICATE_FILE` and `TABPY_KEY_FILE`.
   Details are in the [Configuring HTTP vs HTTPS](#configuring-http-vs-https)
   section.
 - `TABPY_CERTIFICATE_FILE` - absolute path to the certificate file to run


### PR DESCRIPTION
broken link for http vs https.  It seems the lint check for line length caused the markup link to be split across lines, so the link did not work.