### PR TITLE
Enable config file to parse environment variables.

### DIFF
--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -50,6 +50,9 @@ Configuration file consists of settings for TabPy itself and Python logger
 settings. You should only set parameters if you need different values than
 the defaults.
 
+Environment variables can be used in the config file. Any instances of
+`%(ENV_VAR)s` will be replaced by the value of the environment variable `ENV_VAR`.
+
 TabPy parameters explained below, the logger documentation can be found
 at [`logging.config` documentation page](https://docs.python.org/3.6/library/logging.config.html).
 

--- a/tabpy/tabpy_server/app/app.py
+++ b/tabpy/tabpy_server/app/app.py
@@ -183,7 +183,7 @@ class TabPyApp:
                 logger.debug(
                     f'Parameter {settings_key} set to '
                     f'"{self.settings[settings_key]}" '
-                    'from config file')
+                    'from config file or environment variable')
 
             if not key_is_set and default_val is not None:
                 self.settings[settings_key] = default_val
@@ -191,7 +191,7 @@ class TabPyApp:
                 logger.debug(
                     f'Parameter {settings_key} set to '
                     f'"{self.settings[settings_key]}" '
-                    'from default value or environment variable')
+                    'from default value')
 
             if not key_is_set:
                 logger.debug(

--- a/tabpy/tabpy_server/app/app.py
+++ b/tabpy/tabpy_server/app/app.py
@@ -160,7 +160,7 @@ class TabPyApp:
         self.python_service = None
         self.credentials = {}
 
-        parser = configparser.ConfigParser()
+        parser = configparser.ConfigParser(os.environ)
 
         if os.path.isfile(config_file):
             with open(config_file) as f:

--- a/tabpy/tabpy_server/app/app.py
+++ b/tabpy/tabpy_server/app/app.py
@@ -172,8 +172,7 @@ class TabPyApp:
 
         def set_parameter(settings_key,
                           config_key,
-                          default_val=None,
-                          check_env_var=False):
+                          default_val=None):
             key_is_set = False
 
             if config_key is not None and\
@@ -192,20 +191,21 @@ class TabPyApp:
                 logger.debug(
                     f'Parameter {settings_key} set to '
                     f'"{self.settings[settings_key]}" '
-                    'from default value')
+                    'from default value or environment variable')
 
             if not key_is_set:
                 logger.debug(
                     f'Parameter {settings_key} is not set')
 
         set_parameter(SettingsParameters.Port, ConfigParameters.TABPY_PORT,
-                      default_val=9004, check_env_var=True)
+                      default_val=9004)
         set_parameter(SettingsParameters.ServerVersion, None,
                       default_val=__version__)
 
         set_parameter(SettingsParameters.EvaluateTimeout,
                       ConfigParameters.TABPY_EVALUATE_TIMEOUT,
                       default_val=30)
+
         try:
             self.settings[SettingsParameters.EvaluateTimeout] = float(
                 self.settings[SettingsParameters.EvaluateTimeout])
@@ -219,8 +219,7 @@ class TabPyApp:
         set_parameter(SettingsParameters.UploadDir,
                       ConfigParameters.TABPY_QUERY_OBJECT_PATH,
                       default_val=os.path.join(pkg_path,
-                                               'tmp', 'query_objects'),
-                      check_env_var=True)
+                                               'tmp', 'query_objects'))
         if not os.path.exists(self.settings[SettingsParameters.UploadDir]):
             os.makedirs(self.settings[SettingsParameters.UploadDir])
 
@@ -241,8 +240,7 @@ class TabPyApp:
         # last dependence on batch/shell script
         set_parameter(SettingsParameters.StateFilePath,
                       ConfigParameters.TABPY_STATE_PATH,
-                      default_val=os.path.join(pkg_path, 'tabpy_server'),
-                      check_env_var=True)
+                      default_val=os.path.join(pkg_path, 'tabpy_server'))
         self.settings[SettingsParameters.StateFilePath] = os.path.realpath(
             os.path.normpath(
                 os.path.expanduser(

--- a/tabpy/tabpy_server/app/app.py
+++ b/tabpy/tabpy_server/app/app.py
@@ -186,16 +186,6 @@ class TabPyApp:
                     f'"{self.settings[settings_key]}" '
                     'from config file')
 
-            if not key_is_set and check_env_var:
-                val = os.getenv(config_key)
-                if val is not None:
-                    self.settings[settings_key] = val
-                    key_is_set = True
-                    logger.debug(
-                        f'Parameter {settings_key} set to '
-                        f'"{self.settings[settings_key]}" '
-                        'from environment variable')
-
             if not key_is_set and default_val is not None:
                 self.settings[settings_key] = default_val
                 key_is_set = True

--- a/tests/unit/server_tests/test_config.py
+++ b/tests/unit/server_tests/test_config.py
@@ -131,6 +131,21 @@ class TestPartialConfigFile(unittest.TestCase):
         app = TabPyApp(self.config_file.name)
         self.assertEqual(app.settings['evaluate_timeout'], 30.0)
 
+    @patch('tabpy.tabpy_server.app.app.os')
+    @patch('tabpy.tabpy_server.app.app.os.path.exists', return_value=True)
+    @patch('tabpy.tabpy_server.app.app._get_state_from_file')
+    @patch('tabpy.tabpy_server.app.app.TabPyState')
+    def test_env_variables_in_config(self, mock_state, mock_get_state,
+                                     mock_path_exists, mock_os):
+        mock_os.environ = {'foo': 'baz'}
+        config_file = self.config_file
+        config_file.write('[TabPy]\n'
+                          'TABPY_PORT = %(foo)sbar'.encode())
+        config_file.close()
+
+        app = TabPyApp(self.config_file.name)
+        self.assertEqual(app.settings['port'], 'bazbar')
+
 
 class TestTransferProtocolValidation(unittest.TestCase):
     @staticmethod

--- a/tests/unit/server_tests/test_config.py
+++ b/tests/unit/server_tests/test_config.py
@@ -32,16 +32,12 @@ class TestConfigEnvironmentCalls(unittest.TestCase):
         pkg_path = os.path.dirname(tabpy.__file__)
         obj_path = os.path.join(pkg_path, 'tmp', 'query_objects')
         state_path = os.path.join(pkg_path, 'tabpy_server')
-
-        mock_os.getenv.side_effect = [9004, obj_path, state_path]
+        mock_os.environ = {
+            'TABPY_PORT': 9004, 'TABPY_QUERY_OBJECT_PATH': obj_path,
+            'TABPY_STATE_PATH': state_path}
 
         TabPyApp(None)
 
-        getenv_calls = [
-            call('TABPY_PORT'),
-            call('TABPY_QUERY_OBJECT_PATH'),
-            call('TABPY_STATE_PATH')]
-        mock_os.getenv.assert_has_calls(getenv_calls, any_order=True)
         self.assertEqual(len(mock_psws.mock_calls), 1)
         self.assertEqual(len(mock_tabpy_state.mock_calls), 1)
         self.assertEqual(len(mock_path_exists.mock_calls), 1)
@@ -89,15 +85,12 @@ class TestPartialConfigFile(unittest.TestCase):
         config_file.close()
 
         mock_parse_arguments.return_value = Namespace(config=config_file.name)
-
-        mock_os.getenv.side_effect = [1234]
         mock_os.path.realpath.return_value = 'bar'
+        mock_os.environ = {'TABPY_PORT': 1234}
 
         app = TabPyApp(config_file.name)
-        getenv_calls = [call('TABPY_PORT')]
 
-        mock_os.getenv.assert_has_calls(getenv_calls, any_order=True)
-        self.assertEqual(app.settings['port'], 1234)
+        self.assertEqual(app.settings['port'], '1234')
         self.assertEqual(app.settings['server_version'],
                          open('VERSION').read().strip())
         self.assertEqual(app.settings['upload_dir'], 'foo')

--- a/tests/unit/server_tests/test_config.py
+++ b/tests/unit/server_tests/test_config.py
@@ -6,7 +6,7 @@ import tabpy
 from tabpy.tabpy_server.app.util import validate_cert
 from tabpy.tabpy_server.app.app import TabPyApp
 
-from unittest.mock import patch, call
+from unittest.mock import patch
 
 
 def assert_raises_runtime_error(message, fn, args={}):
@@ -33,7 +33,7 @@ class TestConfigEnvironmentCalls(unittest.TestCase):
         obj_path = os.path.join(pkg_path, 'tmp', 'query_objects')
         state_path = os.path.join(pkg_path, 'tabpy_server')
         mock_os.environ = {
-            'TABPY_PORT': 9004, 'TABPY_QUERY_OBJECT_PATH': obj_path,
+            'TABPY_PORT': '9004', 'TABPY_QUERY_OBJECT_PATH': obj_path,
             'TABPY_STATE_PATH': state_path}
 
         TabPyApp(None)
@@ -86,7 +86,7 @@ class TestPartialConfigFile(unittest.TestCase):
 
         mock_parse_arguments.return_value = Namespace(config=config_file.name)
         mock_os.path.realpath.return_value = 'bar'
-        mock_os.environ = {'TABPY_PORT': 1234}
+        mock_os.environ = {'TABPY_PORT': '1234'}
 
         app = TabPyApp(config_file.name)
 


### PR DESCRIPTION
Environment variables can now be used in the config file such that `%(ENV_VAR)s` will be parsed as the value of the environment variable `ENV_VAR`.