### PR TITLE
Updated tabpy-virtualenv.md

### DIFF
--- a/docs/tabpy-virtualenv.md
+++ b/docs/tabpy-virtualenv.md
@@ -27,7 +27,7 @@ To run TabPy in Python virtual environment follow the steps:
    2. For Linux and Mac run
 
       ```sh
-      my-tabpy-env/bin/activate
+      source my-tabpy-env/bin/activate
       ```
 
 4. Run TabPy:


### PR DESCRIPTION
Updated tabpy-virtualenv.md. The activation for OS Linux and Mac requires the word "source" in order for the virtualenv to activate.