### PR TITLE
Removed old py2 inheritance

### DIFF
--- a/tabpy/tabpy_server/common/messages.py
+++ b/tabpy/tabpy_server/common/messages.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 import json
 
 
-class Msg(object):
+class Msg:
     """
     An abstract base class for all messages used for communicating between
     the WebServices.

--- a/tabpy/tabpy_server/handlers/base_handler.py
+++ b/tabpy/tabpy_server/handlers/base_handler.py
@@ -12,7 +12,7 @@ import uuid
 STAGING_THREAD = concurrent.futures.ThreadPoolExecutor(max_workers=3)
 
 
-class ContextLoggerWrapper(object):
+class ContextLoggerWrapper:
     '''
     This class appends request context to logged messages.
     '''

--- a/tabpy/tabpy_server/management/state.py
+++ b/tabpy/tabpy_server/management/state.py
@@ -64,7 +64,7 @@ def get_query_object_path(state_file_path, name, version):
     return full_path
 
 
-class TabPyState(object):
+class TabPyState:
     '''
     The TabPy state object that stores attributes
     about this TabPy and perform GET/SET on these

--- a/tabpy/tabpy_server/psws/python_service.py
+++ b/tabpy/tabpy_server/psws/python_service.py
@@ -50,7 +50,7 @@ class PythonServiceHandler:
             return UnknownMessage(msg)
 
 
-class PythonService(object):
+class PythonService:
     """
     This class is a simple wrapper maintaining loaded query objects from
     the current TabPy instance. `query_objects` is a dictionary that

--- a/tabpy/tabpy_tools/client.py
+++ b/tabpy/tabpy_tools/client.py
@@ -55,7 +55,7 @@ def _check_endpoint_name(name):
             ' underscore, hyphens and spaces.')
 
 
-class Client(object):
+class Client:
     def __init__(self,
                  endpoint,
                  query_timeout=1000):

--- a/tabpy/tabpy_tools/rest.py
+++ b/tabpy/tabpy_tools/rest.py
@@ -33,7 +33,7 @@ class ResponseError(Exception):
                 f'{self.info}')
 
 
-class RequestsNetworkWrapper(object):
+class RequestsNetworkWrapper:
     """The NetworkWrapper wraps the underlying network connection to simplify
     the interface a bit. This can be replaced with something that can be built
     on some other type of network connection, such as PyCURL.
@@ -178,7 +178,7 @@ class RequestsNetworkWrapper(object):
         self.auth = HTTPBasicAuth(username, password)
 
 
-class ServiceClient(object):
+class ServiceClient:
     """
     A generic service client.
 
@@ -235,7 +235,7 @@ class ServiceClient(object):
         self.network_wrapper.set_credentials(username, password)
 
 
-class RESTProperty(object):
+class RESTProperty:
     """A descriptor that will control the type of value stored."""
 
     def __init__(self, type, from_json=lambda x: x, to_json=lambda x: x,

--- a/tabpy/tabpy_tools/rest_client.py
+++ b/tabpy/tabpy_tools/rest_client.py
@@ -118,7 +118,7 @@ class AliasEndpoint(Endpoint):
         self.type = 'alias'
 
 
-class RESTServiceClient(object):
+class RESTServiceClient:
     """A thin client for the REST Service."""
     def __init__(self, service_client):
         self.service_client = service_client


### PR DESCRIPTION
Inheriting from object is a Python 2 relic of "new style classes"; not applicable with Python3