### PR TITLE
Return HTTP 400 status when receiving a request with authentication credentials and authN is not configured

### DIFF
--- a/tabpy/tabpy_server/handlers/base_handler.py
+++ b/tabpy/tabpy_server/handlers/base_handler.py
@@ -127,7 +127,9 @@ class BaseHandler(tornado.web.RequestHandler):
         self.password = None
         self.eval_timeout = self.settings[SettingsParameters.EvaluateTimeout]
 
-        self.authentication_not_required_error = None # this is fragile, depends on handle_authentication function because this gets set in the handle_authentication function
+        # this is fragile, depends on handle_authentication function because 
+        # this gets set in the handle_authentication function
+        self.authentication_not_required_error = None
 
         self.logger = ContextLoggerWrapper(self.request)
         self.logger.enable_context_logging(
@@ -390,11 +392,13 @@ class BaseHandler(tornado.web.RequestHandler):
             return False
 
         if method == "":
-            if not self._get_basic_auth_credentials(): 
-                self.logger.log(logging.DEBUG, "authentication not required, username and password are none")
+            if not self._get_basic_auth_credentials():
+                self.logger.log(logging.DEBUG,
+                    "authentication not required, username and password are none")
                 return True
-            else: 
-                self.logger.log(logging.DEBUG, "authentication not required, username and password are not none")
+            else:
+                self.logger.log(logging.DEBUG,
+                    "authentication not required, username and password are not none")
                 self.authentication_not_required_error = True
                 return False
 
@@ -460,4 +464,3 @@ class BaseHandler(tornado.web.RequestHandler):
             info="Bad request.",
             log_message="Username or Password provided when authentication not available",
         )
-

--- a/tabpy/tabpy_server/handlers/base_handler.py
+++ b/tabpy/tabpy_server/handlers/base_handler.py
@@ -127,7 +127,7 @@ class BaseHandler(tornado.web.RequestHandler):
         self.password = None
         self.eval_timeout = self.settings[SettingsParameters.EvaluateTimeout]
 
-        self.authentication_not_required_error = None # this is fragile, depends on handle_authentication function
+        self.authentication_not_required_error = None # this is fragile, depends on handle_authentication function because this gets set in the handle_authentication function
 
         self.logger = ContextLoggerWrapper(self.request)
         self.logger.enable_context_logging(
@@ -135,7 +135,6 @@ class BaseHandler(tornado.web.RequestHandler):
         )
         self.logger.log(logging.DEBUG, "Checking if need to handle authentication")
         self.not_authorized = not self.handle_authentication("v1")
-
 
     def error_out(self, code, log_message, info=None):
         self.set_status(code)
@@ -396,9 +395,7 @@ class BaseHandler(tornado.web.RequestHandler):
                 return True
             else: 
                 self.logger.log(logging.DEBUG, "authentication not required, username and password are not none")
-                print("gets here")
                 self.authentication_not_required_error = True
-                print(self.authentication_not_required_error)
                 return False
 
         if not self._get_credentials(method):
@@ -449,7 +446,6 @@ class BaseHandler(tornado.web.RequestHandler):
             True when username and password fields are not empty w
             hen authentication is not required
         """
-        print(self.authentication_not_required_error)
         return self.authentication_not_required_error
     
     def fail_with_bad_request(self):

--- a/tabpy/tabpy_server/handlers/base_handler.py
+++ b/tabpy/tabpy_server/handlers/base_handler.py
@@ -134,7 +134,7 @@ class BaseHandler(tornado.web.RequestHandler):
             app.settings[SettingsParameters.LogRequestContext]
         )
         self.logger.log(logging.DEBUG, "Checking if need to handle authentication")
-        self.not_authorized = not self.handle_authentication("v1")
+        self.authentication_error = not self.handle_authentication("v1")
 
     def error_out(self, code, log_message, info=None):
         self.set_status(code)
@@ -419,7 +419,7 @@ class BaseHandler(tornado.web.RequestHandler):
             if authentication is not required and username and password
             fields are not empty.
         """
-        return self.not_authorized
+        return self.authentication_error
 
     def fail_with_not_authorized(self):
         """

--- a/tabpy/tabpy_server/handlers/endpoint_handler.py
+++ b/tabpy/tabpy_server/handlers/endpoint_handler.py
@@ -22,9 +22,13 @@ class EndpointHandler(ManagementHandler):
         super(EndpointHandler, self).initialize(app)
 
     def get(self, endpoint_name):
-        if self.should_fail_with_not_authorized():
-            self.fail_with_not_authorized()
-            return
+        if self.should_fail_with_error():
+            if self.fail_with_authentication_not_required():
+                self.fail_with_bad_request()
+                return
+            else:
+                self.fail_with_not_authorized()
+                return
 
         self.logger.log(logging.DEBUG, f"Processing GET for /endpoints/{endpoint_name}")
 
@@ -43,9 +47,13 @@ class EndpointHandler(ManagementHandler):
 
     @gen.coroutine
     def put(self, name):
-        if self.should_fail_with_not_authorized():
-            self.fail_with_not_authorized()
-            return
+        if self.should_fail_with_error():
+            if self.fail_with_authentication_not_required():
+                self.fail_with_bad_request()
+                return
+            else:
+                self.fail_with_not_authorized()
+                return
 
         self.logger.log(logging.DEBUG, f"Processing PUT for /endpoints/{name}")
 
@@ -89,9 +97,13 @@ class EndpointHandler(ManagementHandler):
 
     @gen.coroutine
     def delete(self, name):
-        if self.should_fail_with_not_authorized():
-            self.fail_with_not_authorized()
-            return
+        if self.should_fail_with_error():
+            if self.fail_with_authentication_not_required():
+                self.fail_with_bad_request()
+                return
+            else:
+                self.fail_with_not_authorized()
+                return
 
         self.logger.log(logging.DEBUG, f"Processing DELETE for /endpoints/{name}")
 

--- a/tabpy/tabpy_server/handlers/endpoint_handler.py
+++ b/tabpy/tabpy_server/handlers/endpoint_handler.py
@@ -14,6 +14,7 @@ from tabpy.tabpy_server.handlers import ManagementHandler
 from tabpy.tabpy_server.handlers.base_handler import STAGING_THREAD
 from tabpy.tabpy_server.management.state import get_query_object_path
 from tabpy.tabpy_server.psws.callbacks import on_state_change
+from tabpy.tabpy_server.handlers.util import AuthErrorStates
 from tornado import gen
 
 
@@ -22,13 +23,9 @@ class EndpointHandler(ManagementHandler):
         super(EndpointHandler, self).initialize(app)
 
     def get(self, endpoint_name):
-        if self.should_fail_with_error():
-            if self.fail_with_authentication_not_required():
-                self.fail_with_bad_request()
-                return
-            else:
-                self.fail_with_not_authorized()
-                return
+        if self.should_fail_with_auth_error() != AuthErrorStates.NONE:
+            self.fail_with_auth_error()
+            return
 
         self.logger.log(logging.DEBUG, f"Processing GET for /endpoints/{endpoint_name}")
 
@@ -47,13 +44,9 @@ class EndpointHandler(ManagementHandler):
 
     @gen.coroutine
     def put(self, name):
-        if self.should_fail_with_error():
-            if self.fail_with_authentication_not_required():
-                self.fail_with_bad_request()
-                return
-            else:
-                self.fail_with_not_authorized()
-                return
+        if self.should_fail_with_auth_error() != AuthErrorStates.NONE:
+            self.fail_with_auth_error()
+            return
 
         self.logger.log(logging.DEBUG, f"Processing PUT for /endpoints/{name}")
 
@@ -97,13 +90,9 @@ class EndpointHandler(ManagementHandler):
 
     @gen.coroutine
     def delete(self, name):
-        if self.should_fail_with_error():
-            if self.fail_with_authentication_not_required():
-                self.fail_with_bad_request()
-                return
-            else:
-                self.fail_with_not_authorized()
-                return
+        if self.should_fail_with_auth_error() != AuthErrorStates.NONE:
+            self.fail_with_auth_error()
+            return
 
         self.logger.log(logging.DEBUG, f"Processing DELETE for /endpoints/{name}")
 

--- a/tabpy/tabpy_server/handlers/endpoints_handler.py
+++ b/tabpy/tabpy_server/handlers/endpoints_handler.py
@@ -10,6 +10,7 @@ import json
 import logging
 from tabpy.tabpy_server.common.util import format_exception
 from tabpy.tabpy_server.handlers import ManagementHandler
+from tabpy.tabpy_server.handlers.util import AuthErrorStates
 from tornado import gen
 
 
@@ -18,26 +19,18 @@ class EndpointsHandler(ManagementHandler):
         super(EndpointsHandler, self).initialize(app)
 
     def get(self):
-        if self.should_fail_with_error():
-            if self.fail_with_authentication_not_required():
-                self.fail_with_bad_request()
-                return
-            else:
-                self.fail_with_not_authorized()
-                return
+        if self.should_fail_with_auth_error() != AuthErrorStates.NONE:
+            self.fail_with_auth_error()
+            return
 
         self._add_CORS_header()
         self.write(json.dumps(self.tabpy_state.get_endpoints()))
 
     @gen.coroutine
     def post(self):
-        if self.should_fail_with_error():
-            if self.fail_with_authentication_not_required():
-                self.fail_with_bad_request()
-                return
-            else:
-                self.fail_with_not_authorized()
-                return
+        if self.should_fail_with_auth_error() != AuthErrorStates.NONE:
+            self.fail_with_auth_error()
+            return
 
         try:
             if not self.request.body:

--- a/tabpy/tabpy_server/handlers/endpoints_handler.py
+++ b/tabpy/tabpy_server/handlers/endpoints_handler.py
@@ -18,18 +18,26 @@ class EndpointsHandler(ManagementHandler):
         super(EndpointsHandler, self).initialize(app)
 
     def get(self):
-        if self.should_fail_with_not_authorized():
-            self.fail_with_not_authorized()
-            return
+        if self.should_fail_with_error():
+            if self.fail_with_authentication_not_required():
+                self.fail_with_bad_request()
+                return
+            else:
+                self.fail_with_not_authorized()
+                return
 
         self._add_CORS_header()
         self.write(json.dumps(self.tabpy_state.get_endpoints()))
 
     @gen.coroutine
     def post(self):
-        if self.should_fail_with_not_authorized():
-            self.fail_with_not_authorized()
-            return
+        if self.should_fail_with_error():
+            if self.fail_with_authentication_not_required():
+                self.fail_with_bad_request()
+                return
+            else:
+                self.fail_with_not_authorized()
+                return
 
         try:
             if not self.request.body:

--- a/tabpy/tabpy_server/handlers/evaluation_plane_handler.py
+++ b/tabpy/tabpy_server/handlers/evaluation_plane_handler.py
@@ -6,6 +6,7 @@ from tabpy.tabpy_server.common.util import format_exception
 import requests
 from tornado import gen
 from datetime import timedelta
+from tabpy.tabpy_server.handlers.util import AuthErrorStates
 
 
 class RestrictedTabPy:
@@ -100,13 +101,9 @@ class EvaluationPlaneHandler(BaseHandler):
 
     @gen.coroutine
     def post(self):
-        if self.should_fail_with_error():
-            if self.fail_with_authentication_not_required():
-                self.fail_with_bad_request()
-                return
-            else:
-                self.fail_with_not_authorized()
-                return
+        if self.should_fail_with_auth_error() != AuthErrorStates.NONE:
+            self.fail_with_auth_error()
+            return
 
         self._add_CORS_header()
         try:

--- a/tabpy/tabpy_server/handlers/evaluation_plane_handler.py
+++ b/tabpy/tabpy_server/handlers/evaluation_plane_handler.py
@@ -100,9 +100,13 @@ class EvaluationPlaneHandler(BaseHandler):
 
     @gen.coroutine
     def post(self):
-        if self.should_fail_with_not_authorized():
-            self.fail_with_not_authorized()
-            return
+        if self.should_fail_with_error():
+            if self.fail_with_authentication_not_required():
+                self.fail_with_bad_request()
+                return
+            else:
+                self.fail_with_not_authorized()
+                return
 
         self._add_CORS_header()
         try:

--- a/tabpy/tabpy_server/handlers/query_plane_handler.py
+++ b/tabpy/tabpy_server/handlers/query_plane_handler.py
@@ -67,9 +67,13 @@ class QueryPlaneHandler(BaseHandler):
     # don't check API key (client does not send or receive data for OPTIONS,
     # it just allows the client to subsequently make a POST request)
     def options(self, pred_name):
-        if self.should_fail_with_not_authorized():
-            self.fail_with_not_authorized()
-            return
+        if self.should_fail_with_error():
+            if self.fail_with_authentication_not_required():
+                self.fail_with_bad_request()
+                return
+            else:
+                self.fail_with_not_authorized()
+                return
 
         self.logger.log(logging.DEBUG, f"Processing OPTIONS for /query/{pred_name}")
 
@@ -212,9 +216,13 @@ class QueryPlaneHandler(BaseHandler):
 
     @gen.coroutine
     def get(self, endpoint_name):
-        if self.should_fail_with_not_authorized():
-            self.fail_with_not_authorized()
-            return
+        if self.should_fail_with_error():
+            if self.fail_with_authentication_not_required():
+                self.fail_with_bad_request()
+                return
+            else:
+                self.fail_with_not_authorized()
+                return
 
         start = time.time()
         endpoint_name = urllib.parse.unquote(endpoint_name)
@@ -224,9 +232,13 @@ class QueryPlaneHandler(BaseHandler):
     def post(self, endpoint_name):
         self.logger.log(logging.DEBUG, f"Processing POST for /query/{endpoint_name}...")
 
-        if self.should_fail_with_not_authorized():
-            self.fail_with_not_authorized()
-            return
+        if self.should_fail_with_error():
+            if self.fail_with_authentication_not_required():
+                self.fail_with_bad_request()
+                return
+            else:
+                self.fail_with_not_authorized()
+                return
 
         start = time.time()
         endpoint_name = urllib.parse.unquote(endpoint_name)

--- a/tabpy/tabpy_server/handlers/query_plane_handler.py
+++ b/tabpy/tabpy_server/handlers/query_plane_handler.py
@@ -13,6 +13,7 @@ import json
 from tabpy.tabpy_server.common.util import format_exception
 import urllib
 from tornado import gen
+from tabpy.tabpy_server.handlers.util import AuthErrorStates
 
 
 def _get_uuid():
@@ -67,13 +68,9 @@ class QueryPlaneHandler(BaseHandler):
     # don't check API key (client does not send or receive data for OPTIONS,
     # it just allows the client to subsequently make a POST request)
     def options(self, pred_name):
-        if self.should_fail_with_error():
-            if self.fail_with_authentication_not_required():
-                self.fail_with_bad_request()
-                return
-            else:
-                self.fail_with_not_authorized()
-                return
+        if self.should_fail_with_auth_error() != AuthErrorStates.NONE:
+            self.fail_with_auth_error()
+            return
 
         self.logger.log(logging.DEBUG, f"Processing OPTIONS for /query/{pred_name}")
 
@@ -216,13 +213,9 @@ class QueryPlaneHandler(BaseHandler):
 
     @gen.coroutine
     def get(self, endpoint_name):
-        if self.should_fail_with_error():
-            if self.fail_with_authentication_not_required():
-                self.fail_with_bad_request()
-                return
-            else:
-                self.fail_with_not_authorized()
-                return
+        if self.should_fail_with_auth_error() != AuthErrorStates.NONE:
+            self.fail_with_auth_error()
+            return
 
         start = time.time()
         endpoint_name = urllib.parse.unquote(endpoint_name)
@@ -232,13 +225,9 @@ class QueryPlaneHandler(BaseHandler):
     def post(self, endpoint_name):
         self.logger.log(logging.DEBUG, f"Processing POST for /query/{endpoint_name}...")
 
-        if self.should_fail_with_error():
-            if self.fail_with_authentication_not_required():
-                self.fail_with_bad_request()
-                return
-            else:
-                self.fail_with_not_authorized()
-                return
+        if self.should_fail_with_auth_error() != AuthErrorStates.NONE:
+            self.fail_with_auth_error()
+            return
 
         start = time.time()
         endpoint_name = urllib.parse.unquote(endpoint_name)

--- a/tabpy/tabpy_server/handlers/service_info_handler.py
+++ b/tabpy/tabpy_server/handlers/service_info_handler.py
@@ -8,9 +8,13 @@ class ServiceInfoHandler(ManagementHandler):
         super(ServiceInfoHandler, self).initialize(app)
 
     def get(self):
-        if self.should_fail_with_not_authorized():
-            self.fail_with_not_authorized()
-            return
+        if self.should_fail_with_error():
+            if self.fail_with_authentication_not_required():
+                self.fail_with_bad_request()
+                return
+            else:
+                self.fail_with_not_authorized()
+                return
 
         self._add_CORS_header()
         info = {}

--- a/tabpy/tabpy_server/handlers/service_info_handler.py
+++ b/tabpy/tabpy_server/handlers/service_info_handler.py
@@ -1,20 +1,16 @@
 import json
 from tabpy.tabpy_server.app.SettingsParameters import SettingsParameters
 from tabpy.tabpy_server.handlers import ManagementHandler
-
+from tabpy.tabpy_server.handlers.util import AuthErrorStates
 
 class ServiceInfoHandler(ManagementHandler):
     def initialize(self, app):
         super(ServiceInfoHandler, self).initialize(app)
 
     def get(self):
-        if self.should_fail_with_error():
-            if self.fail_with_authentication_not_required():
-                self.fail_with_bad_request()
-                return
-            else:
-                self.fail_with_not_authorized()
-                return
+        if self.should_fail_with_auth_error() != AuthErrorStates.NONE:
+            self.fail_with_auth_error()
+            return
 
         self._add_CORS_header()
         info = {}

--- a/tabpy/tabpy_server/handlers/status_handler.py
+++ b/tabpy/tabpy_server/handlers/status_handler.py
@@ -8,9 +8,13 @@ class StatusHandler(BaseHandler):
         super(StatusHandler, self).initialize(app)
 
     def get(self):
-        if self.should_fail_with_not_authorized():
-            self.fail_with_not_authorized()
-            return
+        if self.should_fail_with_error():
+            if self.fail_with_authentication_not_required():
+                self.fail_with_bad_request()
+                return
+            else:
+                self.fail_with_not_authorized()
+                return
 
         self._add_CORS_header()
 

--- a/tabpy/tabpy_server/handlers/status_handler.py
+++ b/tabpy/tabpy_server/handlers/status_handler.py
@@ -1,20 +1,16 @@
 import json
 import logging
 from tabpy.tabpy_server.handlers import BaseHandler
-
+from tabpy.tabpy_server.handlers.util import AuthErrorStates
 
 class StatusHandler(BaseHandler):
     def initialize(self, app):
         super(StatusHandler, self).initialize(app)
 
     def get(self):
-        if self.should_fail_with_error():
-            if self.fail_with_authentication_not_required():
-                self.fail_with_bad_request()
-                return
-            else:
-                self.fail_with_not_authorized()
-                return
+        if self.should_fail_with_auth_error() != AuthErrorStates.NONE:
+            self.fail_with_auth_error()
+            return
 
         self._add_CORS_header()
 

--- a/tabpy/tabpy_server/handlers/upload_destination_handler.py
+++ b/tabpy/tabpy_server/handlers/upload_destination_handler.py
@@ -11,9 +11,13 @@ class UploadDestinationHandler(ManagementHandler):
         super(UploadDestinationHandler, self).initialize(app)
 
     def get(self):
-        if self.should_fail_with_not_authorized():
-            self.fail_with_not_authorized()
-            return
+        if self.should_fail_with_error():
+            if self.fail_with_authentication_not_required():
+                self.fail_with_bad_request()
+                return
+            else:
+                self.fail_with_not_authorized()
+                return
 
         path = self.settings[SettingsParameters.StateFilePath]
         path = os.path.join(path, _QUERY_OBJECT_STAGING_FOLDER)

--- a/tabpy/tabpy_server/handlers/upload_destination_handler.py
+++ b/tabpy/tabpy_server/handlers/upload_destination_handler.py
@@ -1,6 +1,7 @@
 from tabpy.tabpy_server.app.SettingsParameters import SettingsParameters
 from tabpy.tabpy_server.handlers import ManagementHandler
 import os
+from tabpy.tabpy_server.handlers.util import AuthErrorStates
 
 
 _QUERY_OBJECT_STAGING_FOLDER = "staging"
@@ -11,13 +12,9 @@ class UploadDestinationHandler(ManagementHandler):
         super(UploadDestinationHandler, self).initialize(app)
 
     def get(self):
-        if self.should_fail_with_error():
-            if self.fail_with_authentication_not_required():
-                self.fail_with_bad_request()
-                return
-            else:
-                self.fail_with_not_authorized()
-                return
+        if self.should_fail_with_auth_error() != AuthErrorStates.NONE:
+            self.fail_with_auth_error()
+            return
 
         path = self.settings[SettingsParameters.StateFilePath]
         path = os.path.join(path, _QUERY_OBJECT_STAGING_FOLDER)

--- a/tabpy/tabpy_server/handlers/util.py
+++ b/tabpy/tabpy_server/handlers/util.py
@@ -1,6 +1,11 @@
 import binascii
 from hashlib import pbkdf2_hmac
+from enum import Enum, auto
 
+class AuthErrorStates(Enum):
+    NONE = auto()
+    NotAuthorized = auto()
+    NotRequired = auto()
 
 def hash_password(username, pwd):
     """

--- a/tests/unit/server_tests/test_endpoint_handler.py
+++ b/tests/unit/server_tests/test_endpoint_handler.py
@@ -111,3 +111,54 @@ class TestEndpointHandlerWithAuth(AsyncHTTPTestCase):
             },
         )
         self.assertEqual(404, response.code)
+
+    
+class TestEndpointHandlerWithoutAuth(AsyncHTTPTestCase):
+    @classmethod
+    def setUpClass(cls):
+        _init_asyncio_patch()
+        prefix = "__TestEndpointHandlerWithoutAuth_"
+
+        # create state.ini dir and file
+        cls.state_dir = tempfile.mkdtemp(prefix=prefix)
+        cls.state_file = open(os.path.join(cls.state_dir, "state.ini"), "w+")
+        cls.state_file.write(
+            "[Service Info]\n"
+            "Name = TabPy Serve\n"
+            "Description = \n"
+            "Creation Time = 0\n"
+            "Access-Control-Allow-Origin = \n"
+            "Access-Control-Allow-Headers = \n"
+            "Access-Control-Allow-Methods = \n"
+            "\n"
+            "[Query Objects Service Versions]\n"
+            "\n"
+            "[Query Objects Docstrings]\n"
+            "\n"
+            "[Meta]\n"
+            "Revision Number = 1\n"
+        )
+        cls.state_file.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(cls.state_file.name)
+        os.rmdir(cls.state_dir)
+
+    def get_app(self):
+        self.app = TabPyApp(None)
+        return self.app._create_tornado_web_app()
+
+    def test_creds_no_auth_fails(self):
+        response = self.fetch(
+            "/endpoints/",
+            method="GET",
+            headers={
+                "Authorization": "Basic {}".format(
+                    base64.b64encode("username:password".encode("utf-8")).decode(
+                        "utf-8"
+                    )
+                )
+            },
+        )
+        self.assertEqual(400, response.code)

--- a/tests/unit/server_tests/test_endpoint_handler.py
+++ b/tests/unit/server_tests/test_endpoint_handler.py
@@ -112,7 +112,6 @@ class TestEndpointHandlerWithAuth(AsyncHTTPTestCase):
         )
         self.assertEqual(404, response.code)
 
-    
 class TestEndpointHandlerWithoutAuth(AsyncHTTPTestCase):
     @classmethod
     def setUpClass(cls):
@@ -162,3 +161,4 @@ class TestEndpointHandlerWithoutAuth(AsyncHTTPTestCase):
             },
         )
         self.assertEqual(400, response.code)
+        

--- a/tests/unit/server_tests/test_endpoints_handler.py
+++ b/tests/unit/server_tests/test_endpoints_handler.py
@@ -94,3 +94,53 @@ class TestEndpointsHandlerWithAuth(AsyncHTTPTestCase):
             },
         )
         self.assertEqual(200, response.code)
+
+
+class TestEndpointsHandlerWithoutAuth(AsyncHTTPTestCase):
+    @classmethod
+    def setUpClass(cls):
+        prefix = "__TestEndpointsHandlerWithoutAuth_"
+
+        # create state.ini dir and file
+        cls.state_dir = tempfile.mkdtemp(prefix=prefix)
+        cls.state_file = open(os.path.join(cls.state_dir, "state.ini"), "w+")
+        cls.state_file.write(
+            "[Service Info]\n"
+            "Name = TabPy Serve\n"
+            "Description = \n"
+            "Creation Time = 0\n"
+            "Access-Control-Allow-Origin = \n"
+            "Access-Control-Allow-Headers = \n"
+            "Access-Control-Allow-Methods = \n"
+            "\n"
+            "[Query Objects Service Versions]\n"
+            "\n"
+            "[Query Objects Docstrings]\n"
+            "\n"
+            "[Meta]\n"
+            "Revision Number = 1\n"
+        )
+        cls.state_file.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(cls.state_file.name)
+        os.rmdir(cls.state_dir)
+
+    def get_app(self):
+        self.app = TabPyApp(None)
+        return self.app._create_tornado_web_app()
+
+    def test_creds_no_auth_fails(self):
+        response = self.fetch(
+            "/endpoints",
+            method="GET",
+            headers={
+                "Authorization": "Basic {}".format(
+                    base64.b64encode("username:password".encode("utf-8")).decode(
+                        "utf-8"
+                    )
+                )
+            },
+        )
+        self.assertEqual(400, response.code)

--- a/tests/unit/server_tests/test_evaluation_plane_handler.py
+++ b/tests/unit/server_tests/test_evaluation_plane_handler.py
@@ -203,3 +203,86 @@ class TestEvaluationPlainHandlerWithAuth(AsyncHTTPTestCase):
             })
         self.assertEqual(200, response.code)
         self.assertEqual(b'null', response.body)
+
+
+class TestEvaluationPlainHandlerWithoutAuth(AsyncHTTPTestCase):
+    @classmethod
+    def setUpClass(cls):
+        prefix = "__TestEvaluationPlainHandlerWithoutAuth_"
+
+        # create state.ini dir and file
+        cls.state_dir = tempfile.mkdtemp(prefix=prefix)
+        cls.state_file = open(os.path.join(cls.state_dir, "state.ini"), "w+")
+        cls.state_file.write(
+            "[Service Info]\n"
+            "Name = TabPy Serve\n"
+            "Description = \n"
+            "Creation Time = 0\n"
+            "Access-Control-Allow-Origin = \n"
+            "Access-Control-Allow-Headers = \n"
+            "Access-Control-Allow-Methods = \n"
+            "\n"
+            "[Query Objects Service Versions]\n"
+            "\n"
+            "[Query Objects Docstrings]\n"
+            "\n"
+            "[Meta]\n"
+            "Revision Number = 1\n"
+        )
+        cls.state_file.close()
+
+        cls.script = (
+            '{"data":{"_arg1":[2,3],"_arg2":[3,-1]},'
+            '"script":"res=[]\\nfor i in range(len(_arg1)):\\n  '
+            'res.append(_arg1[i] * _arg2[i])\\nreturn res"}'
+        )
+
+        cls.script_not_present = (
+            '{"data":{"_arg1":[2,3],"_arg2":[3,-1]},'
+            '"":"res=[]\\nfor i in range(len(_arg1)):\\n  '
+            'res.append(_arg1[i] * _arg2[i])\\nreturn res"}'
+        )
+
+        cls.args_not_present = (
+            '{"script":"res=[]\\nfor i in range(len(_arg1)):\\n  '
+            'res.append(_arg1[i] * _arg2[i])\\nreturn res"}'
+        )
+
+        cls.args_not_sequential = (
+            '{"data":{"_arg1":[2,3],"_arg3":[3,-1]},'
+            '"script":"res=[]\\nfor i in range(len(_arg1)):\\n  '
+            'res.append(_arg1[i] * _arg3[i])\\nreturn res"}'
+        )
+
+        cls.nan_coverts_to_null =\
+            '{"data":{"_arg1":[2,3],"_arg2":[3,-1]},'\
+            '"script":"return [float(1), float(\\"NaN\\"), float(2)]"}'
+
+        cls.script_returns_none = (
+            '{"data":{"_arg1":[2,3],"_arg2":[3,-1]},'
+            '"script":"return None"}'
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(cls.state_file.name)
+        os.rmdir(cls.state_dir)
+
+    def get_app(self):
+        self.app = TabPyApp(None)
+        return self.app._create_tornado_web_app()
+
+    def test_creds_no_auth_fails(self):
+        response = self.fetch(
+            "/evaluate",
+            method="POST",
+            body=self.script,
+            headers={
+                "Authorization": "Basic {}".format(
+                    base64.b64encode("username:password".encode("utf-8")).decode(
+                        "utf-8"
+                    )
+                )
+            },
+        )
+        self.assertEqual(400, response.code)

--- a/tests/unit/server_tests/test_evaluation_plane_handler.py
+++ b/tests/unit/server_tests/test_evaluation_plane_handler.py
@@ -286,3 +286,4 @@ class TestEvaluationPlainHandlerWithoutAuth(AsyncHTTPTestCase):
             },
         )
         self.assertEqual(400, response.code)
+        

--- a/tests/unit/server_tests/test_service_info_handler.py
+++ b/tests/unit/server_tests/test_service_info_handler.py
@@ -137,20 +137,4 @@ class TestServiceInfoHandlerWithoutAuth(BaseTestServiceInfoHandler):
         }
 
         response = self.fetch("/info", headers=header)
-        self.assertEqual(response.code, 200)
-        actual_response = json.loads(response.body)
-        expected_response = _create_expected_info_response(
-            self.app.settings, self.app.tabpy_state
-        )
-
-        self.assertDictEqual(actual_response, expected_response)
-        self.assertTrue("versions" in actual_response)
-        versions = actual_response["versions"]
-        self.assertTrue("v1" in versions)
-        v1 = versions["v1"]
-        self.assertTrue("features" in v1)
-        features = v1["features"]
-        self.assertDictEqual(
-            {},
-            features,
-        )
+        self.assertEqual(response.code, 400)


### PR DESCRIPTION
When TabPy receives a request with authN credentials, and it it not configured with authentication enabled, it should ignore it and return with a 200 status. Instead, it should return a 400 Bad Request status.

I created another flag authentication_not_required_error that tracks if this specific case happens. I also changed the not_authorized error flag to be authentication_error flag as it now encompasses more than just user not being authorized. The checks in each of the endpoints are also updated to reflect the new scenario and unit tests have been written to test this scenario.