### PR TITLE
use a new argument in rest_client.py

### DIFF
--- a/tabpy/tabpy_tools/rest_client.py
+++ b/tabpy/tabpy_tools/rest_client.py
@@ -50,11 +50,11 @@ class Endpoint(RESTObject):
 
     def __new__(cls, **kwargs):
         """Dispatch to the appropriate class."""
-        cls = {"alias": AliasEndpoint, "model": ModelEndpoint}[kwargs["type"]]
+        cls2 = {"alias": AliasEndpoint, "model": ModelEndpoint}[kwargs["type"]]
 
         """return object.__new__(cls, **kwargs)"""
         """ modified for Python 3"""
-        return object.__new__(cls)
+        return object.__new__(cls2)
 
     def __eq__(self, other):
         return (


### PR DESCRIPTION
this method accepts a cls value but then immediately reassigns it.  Fix this code smell to make this file a tiny bit easier to maintain by introducing a new variable name