### PR TITLE
Allow to set NLTK options via TabPy config

### DIFF
--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -91,6 +91,12 @@ at [`logging.config` documentation page](https://docs.python.org/3.6/library/log
   value - `30`. This timeout does not apply when evaluating models either
   through the `/query` method, or using the `tabpy.query(...)` syntax with
   the `/evaluate` method.
+  
+`[nltk]` parameters:
+
+- `NLTK_DOWNLOAD_PATH` - Set the NLTK download path. Defaul '~/nltk_data'.
+- `NLTK_PROXY` - Set the proxy server used for for NLTK `nltk.download()`.
+
 
 ### Configuration File Example
 
@@ -129,6 +135,14 @@ settings._
 # will run before throwing a TimeoutError.
 # The value should be a float representing the timeout time in seconds.
 # TABPY_EVALUATE_TIMEOUT = 30
+
+[nltk]
+# Set the download directory for nltk downloads.
+# NLTK_DOWNLOAD_PATH = ~/nltk_data
+
+# If TabPy is behind a proxy and it needs to connect to the internet for
+# some tasks, you can define a proxy here.
+# NLTK_PROXY = http://proxy:3128
 
 [loggers]
 keys=root

--- a/tabpy/models/scripts/SentimentAnalysis.py
+++ b/tabpy/models/scripts/SentimentAnalysis.py
@@ -1,3 +1,4 @@
+import sys
 from textblob import TextBlob
 import nltk
 from nltk.sentiment.vader import SentimentIntensityAnalyzer
@@ -10,8 +11,18 @@ _ctx = ssl._create_unverified_context
 ssl._create_default_https_context = _ctx
 
 
-nltk.download("vader_lexicon")
-nltk.download("punkt")
+def setup():
+    file_path = sys.argv[1] if len(sys.argv) > 1 else setup_utils.get_default_config_file_path()
+    config = setup_utils.get_config(file_path)
+    download_dir = None
+    if "nltk" in config:
+        nltk_config = config["nltk"]
+        download_dir = nltk_config.get("NLTK_DOWNLOAD_PATH")
+        if "NLTK_PROXY" in nltk_config:
+            nltk.set_proxy(nltk_config["NLTK_PROXY"])
+
+    nltk.download("vader_lexicon", download_dir=download_dir)
+    nltk.download("punkt", download_dir=download_dir)
 
 
 def SentimentAnalysis(_arg1, library="nltk"):
@@ -45,6 +56,7 @@ def SentimentAnalysis(_arg1, library="nltk"):
 
 
 if __name__ == "__main__":
+    setup()
     setup_utils.deploy_model(
         "Sentiment Analysis",
         SentimentAnalysis,

--- a/tabpy/models/utils/setup_utils.py
+++ b/tabpy/models/utils/setup_utils.py
@@ -13,10 +13,14 @@ def get_default_config_file_path():
     return config_file_path
 
 
-def parse_config(config_file_path):
+def get_config(config_file_path):
     config = configparser.ConfigParser()
     config.read(config_file_path)
-    tabpy_config = config["TabPy"]
+    return config
+
+
+def parse_config(config_file_path):
+    tabpy_config = get_config(config_file_path)["TabPy"]
 
     port = 9004
     if "TABPY_PORT" in tabpy_config:


### PR DESCRIPTION
Create a convenience function to expose the settings file to scripts, added NLTK options to the example script and updated SentimentAnalysis.py to use the download path and proxy settings defined in the nltk parameters in the config.