### PR TITLE
Add toggle to turn off evaluate API

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -14,5 +14,6 @@ you may want to consider the following as you use TabPy:
   - Install new Python packages which can contain binary code.
   - Execute operating system commands.
   - Open network connections to other servers and download files.
-- Evaluate endpoint can be disabled by setting "TABPY_EVALUATE_ENABLE" to
-  false in config file
+- Execution of ad-hoc Python scripts can be disabled by turning off the 
+  /evaluate endpoint. To disable /evaluate endpoint, set "TABPY_EVALUATE_ENABLE"
+  to false in config file.

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,6 +14,6 @@ you may want to consider the following as you use TabPy:
   - Install new Python packages which can contain binary code.
   - Execute operating system commands.
   - Open network connections to other servers and download files.
-- Execution of ad-hoc Python scripts can be disabled by turning off the 
+- Execution of ad-hoc Python scripts can be disabled by turning off the
   /evaluate endpoint. To disable /evaluate endpoint, set "TABPY_EVALUATE_ENABLE"
   to false in config file.

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,3 +14,5 @@ you may want to consider the following as you use TabPy:
   - Install new Python packages which can contain binary code.
   - Execute operating system commands.
   - Open network connections to other servers and download files.
+- Evaluate endpoint can be disabled by setting "TABPY_EVALUATE_ENABLE" to
+  false in config file

--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -87,6 +87,8 @@ at [`logging.config` documentation page](https://docs.python.org/3.6/library/log
 - `TABPY_MAX_REQUEST_SIZE_MB` - maximal request size supported by TabPy server
   in Megabytes. All requests of exceeding size are rejected. Default value is
   100 Mb.
+- `TABPY_EVALUATE_ENABLE` - enable evaluate api. Default
+  value - `true`.
 - `TABPY_EVALUATE_TIMEOUT` - script evaluation timeout in seconds. Default
   value - `30`. This timeout does not apply when evaluating models either
   through the `/query` method, or using the `tabpy.query(...)` syntax with
@@ -124,6 +126,10 @@ settings._
 # specified amount will be rejected by TabPy.
 # Default value is 100 Mb.
 # TABPY_MAX_REQUEST_SIZE_MB = 100
+
+# Toggle for evaluate API
+# Enabled by default. Disabling it will result in 400 error.
+# TABPY_EVALUATE_ENABLE = true
 
 # Configure how long a custom script provided to the /evaluate method
 # will run before throwing a TimeoutError.

--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -87,8 +87,8 @@ at [`logging.config` documentation page](https://docs.python.org/3.6/library/log
 - `TABPY_MAX_REQUEST_SIZE_MB` - maximal request size supported by TabPy server
   in Megabytes. All requests of exceeding size are rejected. Default value is
   100 Mb.
-- `TABPY_EVALUATE_ENABLE` - enable evaluate api. Default
-  value - `true`.
+- `TABPY_EVALUATE_ENABLE` - enable evaluate api to execute ad-hoc Python scripts
+  Default value - `true`.
 - `TABPY_EVALUATE_TIMEOUT` - script evaluation timeout in seconds. Default
   value - `30`. This timeout does not apply when evaluating models either
   through the `/query` method, or using the `tabpy.query(...)` syntax with
@@ -127,8 +127,8 @@ settings._
 # Default value is 100 Mb.
 # TABPY_MAX_REQUEST_SIZE_MB = 100
 
-# Toggle for evaluate API
-# Enabled by default. Disabling it will result in 400 error.
+# Enable evaluate api to execute ad-hoc Python scripts
+# Enabled by default. Disabling it will result in 404 error.
 # TABPY_EVALUATE_ENABLE = true
 
 # Configure how long a custom script provided to the /evaluate method

--- a/tabpy/tabpy_server/app/app.py
+++ b/tabpy/tabpy_server/app/app.py
@@ -259,6 +259,8 @@ class TabPyApp:
         settings_parameters = [
             (SettingsParameters.Port, ConfigParameters.TABPY_PORT, 9004, None),
             (SettingsParameters.ServerVersion, None, __version__, None),
+            (SettingsParameters.EvaluateEnabled, ConfigParameters.TABPY_EVALUATE_ENABLE,
+             True, parser.getboolean),
             (SettingsParameters.EvaluateTimeout, ConfigParameters.TABPY_EVALUATE_TIMEOUT,
              30, parser.getfloat),
             (SettingsParameters.UploadDir, ConfigParameters.TABPY_QUERY_OBJECT_PATH,

--- a/tabpy/tabpy_server/app/app.py
+++ b/tabpy/tabpy_server/app/app.py
@@ -18,6 +18,7 @@ from tabpy.tabpy_server.handlers import (
     EndpointHandler,
     EndpointsHandler,
     EvaluationPlaneHandler,
+    EvaluationPlaneDisabledHandler,
     QueryPlaneHandler,
     ServiceInfoHandler,
     StatusHandler,
@@ -150,7 +151,8 @@ class TabPyApp:
                 ),
                 (
                     self.subdirectory + r"/evaluate",
-                    EvaluationPlaneHandler,
+                    EvaluationPlaneHandler if self.settings[SettingsParameters.EvaluateEnabled]
+                    else EvaluationPlaneDisabledHandler,
                     dict(executor=executor, app=self),
                 ),
                 (

--- a/tabpy/tabpy_server/app/app_parameters.py
+++ b/tabpy/tabpy_server/app/app_parameters.py
@@ -14,6 +14,7 @@ class ConfigParameters:
     TABPY_LOG_DETAILS = "TABPY_LOG_DETAILS"
     TABPY_STATIC_PATH = "TABPY_STATIC_PATH"
     TABPY_MAX_REQUEST_SIZE_MB = "TABPY_MAX_REQUEST_SIZE_MB"
+    TABPY_EVALUATE_ENABLE = "TABPY_EVALUATE_ENABLE"
     TABPY_EVALUATE_TIMEOUT = "TABPY_EVALUATE_TIMEOUT"
 
 
@@ -34,3 +35,4 @@ class SettingsParameters:
     StaticPath = "static_path"
     MaxRequestSizeInMb = "max_request_size_in_mb"
     EvaluateTimeout = "evaluate_timeout"
+    EvaluateEnabled = "evaluate_enabled"

--- a/tabpy/tabpy_server/common/default.conf
+++ b/tabpy/tabpy_server/common/default.conf
@@ -25,8 +25,8 @@
 # Default value is 100 Mb.
 # TABPY_MAX_REQUEST_SIZE_MB = 100
 
-# Enable evaluate endpoint
-# Default value is true
+# Toggle for evaluate API
+# Enabled by default. Disabling it will result in 400 error.
 # TABPY_EVALUATE_ENABLE = true
 
 # Configure how long a custom script provided to the /evaluate method

--- a/tabpy/tabpy_server/common/default.conf
+++ b/tabpy/tabpy_server/common/default.conf
@@ -25,8 +25,8 @@
 # Default value is 100 Mb.
 # TABPY_MAX_REQUEST_SIZE_MB = 100
 
-# Toggle for evaluate API
-# Enabled by default. Disabling it will result in 400 error.
+# Enable evaluate api to execute ad-hoc Python scripts
+# Enabled by default. Disabling it will result in 404 error.
 # TABPY_EVALUATE_ENABLE = true
 
 # Configure how long a custom script provided to the /evaluate method

--- a/tabpy/tabpy_server/common/default.conf
+++ b/tabpy/tabpy_server/common/default.conf
@@ -25,6 +25,10 @@
 # Default value is 100 Mb.
 # TABPY_MAX_REQUEST_SIZE_MB = 100
 
+# Enable evaluate endpoint
+# Default value is true
+# TABPY_EVALUATE_ENABLE = true
+
 # Configure how long a custom script provided to the /evaluate method
 # will run before throwing a TimeoutError.
 # The value should be a float representing the timeout time in seconds.

--- a/tabpy/tabpy_server/handlers/__init__.py
+++ b/tabpy/tabpy_server/handlers/__init__.py
@@ -3,6 +3,7 @@ from tabpy.tabpy_server.handlers.management_handler import ManagementHandler
 
 from tabpy.tabpy_server.handlers.endpoint_handler import EndpointHandler
 from tabpy.tabpy_server.handlers.endpoints_handler import EndpointsHandler
+from tabpy.tabpy_server.handlers.evaluation_plane_handler import EvaluationPlaneDisabledHandler
 from tabpy.tabpy_server.handlers.evaluation_plane_handler import EvaluationPlaneHandler
 from tabpy.tabpy_server.handlers.query_plane_handler import QueryPlaneHandler
 from tabpy.tabpy_server.handlers.service_info_handler import ServiceInfoHandler

--- a/tabpy/tabpy_server/handlers/base_handler.py
+++ b/tabpy/tabpy_server/handlers/base_handler.py
@@ -126,6 +126,7 @@ class BaseHandler(tornado.web.RequestHandler):
         self.credentials = app.credentials
         self.username = None
         self.password = None
+        self.eval_enabled = self.settings[SettingsParameters.EvaluateEnabled]
         self.eval_timeout = self.settings[SettingsParameters.EvaluateTimeout]
 
         self.logger = ContextLoggerWrapper(self.request)

--- a/tabpy/tabpy_server/handlers/base_handler.py
+++ b/tabpy/tabpy_server/handlers/base_handler.py
@@ -126,7 +126,6 @@ class BaseHandler(tornado.web.RequestHandler):
         self.credentials = app.credentials
         self.username = None
         self.password = None
-        self.eval_enabled = self.settings[SettingsParameters.EvaluateEnabled]
         self.eval_timeout = self.settings[SettingsParameters.EvaluateTimeout]
 
         self.logger = ContextLoggerWrapper(self.request)

--- a/tabpy/tabpy_server/handlers/evaluation_plane_handler.py
+++ b/tabpy/tabpy_server/handlers/evaluation_plane_handler.py
@@ -44,6 +44,10 @@ class EvaluationPlaneHandler(BaseHandler):
 
     @gen.coroutine
     def _post_impl(self):
+        if not self.eval_enabled:
+            self.error_out(400, "Evaluate action is disabled.")
+            return
+
         body = json.loads(self.request.body.decode("utf-8"))
         self.logger.log(logging.DEBUG, f"Processing POST request '{body}'...")
         if "script" not in body:

--- a/tabpy/tabpy_server/handlers/evaluation_plane_handler.py
+++ b/tabpy/tabpy_server/handlers/evaluation_plane_handler.py
@@ -29,6 +29,21 @@ class RestrictedTabPy:
         return response.json()
 
 
+class EvaluationPlaneDisabledHandler(BaseHandler):
+    """
+    EvaluationPlaneDisabledHandler responds with error message when ad-hoc scripts have been disabled.
+    """
+
+    def initialize(self, executor, app):
+        super(EvaluationPlaneDisabledHandler, self).initialize(app)
+        self.executor = executor
+
+    @gen.coroutine
+    def post(self):
+        self.error_out(404, "Ad-hoc scripts have been disabled on this analytics extension, please contact your "
+                            "administrator.")
+
+
 class EvaluationPlaneHandler(BaseHandler):
     """
     EvaluationPlaneHandler is responsible for running arbitrary python scripts.
@@ -44,11 +59,6 @@ class EvaluationPlaneHandler(BaseHandler):
 
     @gen.coroutine
     def _post_impl(self):
-        if not self.eval_enabled:
-            self.error_out(400, "Ad-hoc scripts have been disabled on this analytics extension, please contact your "
-                                "administrator.")
-            return
-
         body = json.loads(self.request.body.decode("utf-8"))
         self.logger.log(logging.DEBUG, f"Processing POST request '{body}'...")
         if "script" not in body:

--- a/tabpy/tabpy_server/handlers/evaluation_plane_handler.py
+++ b/tabpy/tabpy_server/handlers/evaluation_plane_handler.py
@@ -45,7 +45,7 @@ class EvaluationPlaneHandler(BaseHandler):
     @gen.coroutine
     def _post_impl(self):
         if not self.eval_enabled:
-            self.error_out(400, "Evaluate action is disabled.")
+            self.error_out(400, "Evaluate endpoint is disabled.")
             return
 
         body = json.loads(self.request.body.decode("utf-8"))

--- a/tabpy/tabpy_server/handlers/evaluation_plane_handler.py
+++ b/tabpy/tabpy_server/handlers/evaluation_plane_handler.py
@@ -45,7 +45,8 @@ class EvaluationPlaneHandler(BaseHandler):
     @gen.coroutine
     def _post_impl(self):
         if not self.eval_enabled:
-            self.error_out(400, "Evaluate endpoint is disabled.")
+            self.error_out(400, "Ad-hoc scripts have been disabled on this analytics extension, please contact your "
+                                "administrator.")
             return
 
         body = json.loads(self.request.body.decode("utf-8"))

--- a/tabpy/tabpy_server/handlers/service_info_handler.py
+++ b/tabpy/tabpy_server/handlers/service_info_handler.py
@@ -20,4 +20,5 @@ class ServiceInfoHandler(ManagementHandler):
         info["server_version"] = self.settings[SettingsParameters.ServerVersion]
         info["name"] = self.tabpy_state.name
         info["versions"] = self.settings[SettingsParameters.ApiVersions]
+        info["evaluate_enabled"] = self.settings[SettingsParameters.EvaluateEnabled]
         self.write(json.dumps(info))

--- a/tests/unit/server_tests/test_evaluation_plane_handler.py
+++ b/tests/unit/server_tests/test_evaluation_plane_handler.py
@@ -323,7 +323,7 @@ class TestEvaluationPlainHandlerDisabled(AsyncHTTPTestCase):
             method="POST",
             body=self.script
         )
-        self.assertEqual(400, response.code)
+        self.assertEqual(404, response.code)
 
 
 class TestEvaluationPlainHandlerEnabled(AsyncHTTPTestCase):

--- a/tests/unit/server_tests/test_evaluation_plane_handler.py
+++ b/tests/unit/server_tests/test_evaluation_plane_handler.py
@@ -286,3 +286,89 @@ class TestEvaluationPlainHandlerWithoutAuth(AsyncHTTPTestCase):
             },
         )
         self.assertEqual(400, response.code)
+
+class TestEvaluationPlainHandlerDisabled(AsyncHTTPTestCase):
+    @classmethod
+    def setUpClass(cls):
+        prefix = "__TestEvaluationPlainHandlerDisabled_"
+
+        # create state.ini dir and file
+        cls.state_dir = tempfile.mkdtemp(prefix=prefix)
+        cls.state_file = open(os.path.join(cls.state_dir, "state.ini"), "w+")
+        cls.state_file.write(
+            "[Service Info]\n"
+            "Name = TabPy Serve\n"
+            "Description = \n"
+            "Creation Time = 0\n"
+            "Access-Control-Allow-Origin = \n"
+            "Access-Control-Allow-Headers = \n"
+            "Access-Control-Allow-Methods = \n"
+            "\n"
+            "[Query Objects Service Versions]\n"
+            "\n"
+            "[Query Objects Docstrings]\n"
+            "\n"
+            "[Meta]\n"
+            "Revision Number = 1\n"
+        )
+        cls.state_file.close()
+
+        cls.script = (
+            '{"data":{"_arg1":[2,3],"_arg2":[3,-1]},'
+            '"script":"res=[]\\nfor i in range(len(_arg1)):\\n  '
+            'res.append(_arg1[i] * _arg2[i])\\nreturn res"}'
+        )
+
+        cls.script_not_present = (
+            '{"data":{"_arg1":[2,3],"_arg2":[3,-1]},'
+            '"":"res=[]\\nfor i in range(len(_arg1)):\\n  '
+            'res.append(_arg1[i] * _arg2[i])\\nreturn res"}'
+        )
+
+        cls.args_not_present = (
+            '{"script":"res=[]\\nfor i in range(len(_arg1)):\\n  '
+            'res.append(_arg1[i] * _arg2[i])\\nreturn res"}'
+        )
+
+        cls.args_not_sequential = (
+            '{"data":{"_arg1":[2,3],"_arg3":[3,-1]},'
+            '"script":"res=[]\\nfor i in range(len(_arg1)):\\n  '
+            'res.append(_arg1[i] * _arg3[i])\\nreturn res"}'
+        )
+
+        cls.nan_coverts_to_null =\
+            '{"data":{"_arg1":[2,3],"_arg2":[3,-1]},'\
+            '"script":"return [float(1), float(\\"NaN\\"), float(2)]"}'
+
+        cls.script_returns_none = (
+            '{"data":{"_arg1":[2,3],"_arg2":[3,-1]},'
+            '"script":"return None"}'
+        )
+
+        # create config file
+        cls.config_file = tempfile.NamedTemporaryFile(
+            mode="w+t", prefix=prefix, suffix=".conf", delete=False
+        )
+        cls.config_file.write(
+            "[TabPy]\n"
+            f"TABPY_EVALUATE_ENABLE = false"
+        )
+        cls.config_file.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(cls.state_file.name)
+        os.rmdir(cls.state_dir)
+        os.remove(cls.config_file.name)
+
+    def get_app(self):
+        self.app = TabPyApp(self.config_file.name)
+        return self.app._create_tornado_web_app()
+
+    def test_evaluation_disabled_fails(self):
+        response = self.fetch(
+            "/evaluate",
+            method="POST",
+            body=self.script
+        )
+        self.assertEqual(400, response.code)

--- a/tests/unit/server_tests/test_evaluation_plane_handler.py
+++ b/tests/unit/server_tests/test_evaluation_plane_handler.py
@@ -299,7 +299,7 @@ class TestEvaluationPlainHandlerDisabled(AsyncHTTPTestCase):
         )
         cls.config_file.write(
             "[TabPy]\n"
-            f"TABPY_EVALUATE_ENABLE = true"
+            f"TABPY_EVALUATE_ENABLE = false"
         )
         cls.config_file.close()
 

--- a/tests/unit/server_tests/test_service_info_handler.py
+++ b/tests/unit/server_tests/test_service_info_handler.py
@@ -15,6 +15,7 @@ def _create_expected_info_response(settings, tabpy_state):
         "server_version": settings[SettingsParameters.ServerVersion],
         "name": tabpy_state.name,
         "versions": settings["versions"],
+        "evaluate_enabled": settings["evaluate_enabled"]
     }
 
 
@@ -103,6 +104,7 @@ class TestServiceInfoHandlerWithAuth(BaseTestServiceInfoHandler):
             {"authentication": {"methods": {"basic-auth": {}}, "required": True}},
             features,
         )
+        self.assertTrue(actual_response['evaluate_enabled'])
 
 
 class TestServiceInfoHandlerWithoutAuth(BaseTestServiceInfoHandler):
@@ -127,6 +129,7 @@ class TestServiceInfoHandlerWithoutAuth(BaseTestServiceInfoHandler):
         self.assertTrue("features" in v1)
         features = v1["features"]
         self.assertDictEqual({}, features)
+        self.assertTrue(actual_response['evaluate_enabled'])
 
     def test_given_server_with_no_auth_and_password_expect_correct_info_response(self):
         header = {


### PR DESCRIPTION
For security reasons, some clients want to turn off ad hoc python scripts.

Added a new parameter "TABPY_EVALUATE_ENABLE" to TabPy’s configuration file (True by default)
It will serve as a toggle control to TabPy’s evaluate endpoint