### PR TITLE
fix link in tabpy-tools

### DIFF
--- a/docs/tabpy-tools.md
+++ b/docs/tabpy-tools.md
@@ -426,7 +426,7 @@ Response:
 
 The other core functionality aside from deploying and querying methods as endpoints
 is the ad-hoc execution of Python code, called `evaluate`. Evaluate does not
-have a Python API in `tabpy-tools`, only a raw [REST interface](server-rest.md#httppost-evaluate)
+have a Python API in `tabpy-tools`, only a raw [REST interface](server-rest.md)
 that other client bindings can easily implement. Tableau connects to TabPy
 using REST `Evaluate`.
 


### PR DESCRIPTION
This link broke with change 7fe5d93f9e946fa967e4a8c112b3aa4a0272e0d4 back on 4/29/2019 when the evaluate command was removed.  Just point to the rest docs in general