### PR TITLE
Remove broken URL

### DIFF
--- a/tabpy/tabpy_server/static/index.html
+++ b/tabpy/tabpy_server/static/index.html
@@ -65,7 +65,6 @@ loadModels()
 <li><a href="https://tableau.github.io/TabPy/">TabPy Documentation</a></li>
 <li><a href="https://github.com/tableau/TabPy">TabPy Source Code</a></li>
 <li><a href="https://pypi.org/project/tabpy/">TabPy PyPi</a></li>
-<li><a href="http://tabscifi.com">Tableau Sci-Fi - Advanced Analytics Team blog</a></li>
 </ul>
 
 </body>


### PR DESCRIPTION
This URL (http://tabscifi.com/) is not being used so it could be a potential security concern