### PR TITLE
Update deploy-to-heroku.md

### DIFF
--- a/docs/deploy-to-heroku.md
+++ b/docs/deploy-to-heroku.md
@@ -9,3 +9,5 @@ To deploy TabPy from master branch to a Heroku account:
 
 3. Configure the new TabPy server by setting environment
     variables through Heroku's web console or API.
+
+4. TabPy will run on the default secure port 443.


### PR DESCRIPTION
Note TabPy runs in Heroku on port 443.