### PR TITLE
Security: Add README note for running TabPy without authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ Consider reading TabPy documentation in the following order:
 * [Authoring Python calculations in Tableau](docs/TableauConfiguration.md).
 * [TabPy Tools](docs/tabpy-tools.md)
 
+Important security note:
+
+* By default, TabPy is configured without username/password authentication.
+We strongly advise using TabPy only with authentication enabled. For more
+information, see
+[TabPy Server Configuration Instructions](docs/server-config.md#authentication).
+Without authentication in place, if the TABPY_EVALUATE_ENABLE feature is
+enabled (as it is by default), there is the possibility that unauthenticated
+individuals could remotely execute code on the machine running TabPy.
+Leaving these two settings in their default states together is highly
+discouraged.
+
 Troubleshooting:
 
 * [TabPy Wiki](https://github.com/tableau/TabPy/wiki)

--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -314,14 +314,14 @@ For extended logging (e.g. for auditing purposes) additional logging can be turn
 on with setting `TABPY_LOG_DETAILS` configuration file parameter to `true`.
 
 With the feature on additional information is logged for HTTP requests: caller ip,
-URL, client infomation (Tableau Desktop\Server), Tableau user name (for Tableau Server)
-and TabPy user name as shown in the example below:
+URL, client infomation (Tableau Desktop\Server) and TabPy user name as shown in
+the example below:
 
 <!-- markdownlint-disable MD013 -->
 <!-- markdownlint-disable MD040 -->
 
 ```
-2019-05-02,13:50:08 [INFO] (base_handler.py:base_handler:90): Call ID: 934073bd-0d29-46d3-b693-b1e4b1efa9e4, Caller: ::1, Method: POST, Resource: http://localhost:9004/evaluate, Client: Postman for manual testing, Tableau user: ogolovatyi
+2019-05-02,13:50:08 [INFO] (base_handler.py:base_handler:90): Call ID: 934073bd-0d29-46d3-b693-b1e4b1efa9e4, Caller: ::1, Method: POST, Resource: http://localhost:9004/evaluate, Client: Postman for manual testing
 2019-05-02,13:50:08 [DEBUG] (base_handler.py:base_handler:120): Checking if need to handle authentication, <<
 call ID: 934073bd-0d29-46d3-b693-b1e4b1efa9e4>>
 2019-05-02,13:50:08 [DEBUG] (base_handler.py:base_handler:120): Handling authentication, <<call ID: 934073bd-


### PR DESCRIPTION
- Documentation update: add a note for running TabPy without authentication. A follow up to https://github.com/tableau/TabPy/pull/612.
- Documentation update: remove reference to logging Tableau Server username (currently not supported).
