### PR TITLE
Fix Scrutinizer-CI Failing Dependencies Step

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,6 +20,9 @@ build:
           - pip install -r requirements.txt
       tests:
         override: [py-scrutinizer-run]
+  dependencies: 
+    override: 
+      - pip install .
   tests:
     before:
       - pip install -r requirements.txt


### PR DESCRIPTION
Override `python setup.py install` with `pip install .` in scrutinizer.

Example of failing scrutinizer: https://scrutinizer-ci.com/g/tableau/TabPy/inspections/b52bcab3-75ee-49ea-bd47-2692be0eb2cf

Example of successful scrutinizer (this PR): https://scrutinizer-ci.com/g/tableau/TabPy/inspections/13c4c6e1-8bcb-4a59-ad10-0d41e400e32d