### PR TITLE
W-16337942: updating update_endpoint_info to not increment endpoint version

### DIFF
--- a/docs/tabpy-tools.md
+++ b/docs/tabpy-tools.md
@@ -210,8 +210,7 @@ client.update_endpoint_info('add',
                             schema=updatedSchema)
 ```
 
-Each update of an endpoint will increment its version number, which is also
-returned as part of the query result.
+Updating endpoints via `update_endpoint_info` will NOT increment version number
 
 ## Predeployed Functions
 

--- a/tabpy/tabpy_server/handlers/endpoint_handler.py
+++ b/tabpy/tabpy_server/handlers/endpoint_handler.py
@@ -71,12 +71,12 @@ class EndpointHandler(ManagementHandler):
                 self.finish()
                 return
 
-            new_version = int(endpoints[name]["version"])
+            version_after_update = int(endpoints[name]["version"])
             if request_data.get('should_update_version'):
-                new_version = int(endpoints[name]["version"]) + 1
+                version_after_update = int(endpoints[name]["version"]) + 1
             self.logger.log(logging.INFO, f"Endpoint info: {request_data}")
             err_msg = yield self._add_or_update_endpoint(
-                "update", name, new_version, request_data
+                "update", name, version_after_update, request_data
             )
             if err_msg:
                 self.error_out(400, err_msg)

--- a/tabpy/tabpy_server/handlers/endpoint_handler.py
+++ b/tabpy/tabpy_server/handlers/endpoint_handler.py
@@ -73,7 +73,7 @@ class EndpointHandler(ManagementHandler):
 
             version_after_update = int(endpoints[name]["version"])
             if request_data.get('should_update_version'):
-                version_after_update = int(endpoints[name]["version"]) + 1
+                version_after_update += 1
             self.logger.log(logging.INFO, f"Endpoint info: {request_data}")
             err_msg = yield self._add_or_update_endpoint(
                 "update", name, version_after_update, request_data

--- a/tabpy/tabpy_server/handlers/endpoint_handler.py
+++ b/tabpy/tabpy_server/handlers/endpoint_handler.py
@@ -71,7 +71,9 @@ class EndpointHandler(ManagementHandler):
                 self.finish()
                 return
 
-            new_version = int(endpoints[name]["version"]) + 1
+            new_version = int(endpoints[name]["version"])
+            if request_data.get('should_update_version'):
+                new_version = int(endpoints[name]["version"]) + 1
             self.logger.log(logging.INFO, f"Endpoint info: {request_data}")
             err_msg = yield self._add_or_update_endpoint(
                 "update", name, new_version, request_data

--- a/tabpy/tabpy_tools/client.py
+++ b/tabpy/tabpy_tools/client.py
@@ -251,7 +251,7 @@ class Client:
         if version == 1:
             self._service.add_endpoint(Endpoint(**obj))
         else:
-            self._service.set_endpoint(Endpoint(**obj))
+            self._service.set_endpoint(Endpoint(**obj), should_update_version=True)
 
         self._wait_for_endpoint_deployment(obj["name"], obj["version"])
 

--- a/tabpy/tabpy_tools/client.py
+++ b/tabpy/tabpy_tools/client.py
@@ -323,8 +323,7 @@ class Client:
         endpoint.src_path = os.path.join(
             dest_path, "endpoints", endpoint.name, str(endpoint.version)
         )
-
-        self._service.set_endpoint(endpoint)
+        self._service.set_endpoint(endpoint, should_update_version=False)
 
     def _gen_endpoint(self, name, obj, description, version=1, schema=None, is_public=False):
         """Generates an endpoint dict.

--- a/tabpy/tabpy_tools/rest_client.py
+++ b/tabpy/tabpy_tools/rest_client.py
@@ -204,7 +204,7 @@ class RESTServiceClient:
         """
         return self.service_client.POST("endpoints", endpoint.to_json())
 
-    def set_endpoint(self, endpoint):
+    def set_endpoint(self, endpoint, should_update_version=True):
         """Updates an endpoint through the management API.
 
         Parameters
@@ -213,8 +213,16 @@ class RESTServiceClient:
         endpoint : Endpoint
 
             The endpoint to update.
+
+        should_update_version : bool
+
+            Whether this update should increment the version.
+            False if this is called from update_endpoint_info
+            True if called from deploy
         """
-        return self.service_client.PUT("endpoints/" + endpoint.name, endpoint.to_json())
+        request_body = endpoint.to_json()
+        request_body["should_update_version"] = should_update_version
+        return self.service_client.PUT("endpoints/" + endpoint.name, request_body)
 
     def remove_endpoint(self, endpoint_name):
         """Deletes an endpoint through the management API.


### PR DESCRIPTION
Updated set_endpoint to take an optional parameter that determines whether or not we should update an endpoints version. In the case of update_endpoint_info we are updating an endpoints metadata and so we do not want to update the version. In the case of deploy, we will default to updating the version.