### PR TITLE
W-17092332: Fix for updating functions without is_public set

### DIFF
--- a/tabpy/tabpy_server/management/state.py
+++ b/tabpy/tabpy_server/management/state.py
@@ -188,7 +188,6 @@ class TabPyState:
         return dependencies
 
     def _check_and_set_is_public(self, is_public, defaultValue):
-        logger.log(logging.INFO, f"set is_public")
         if is_public is None:
             return defaultValue
 

--- a/tabpy/tabpy_server/management/state.py
+++ b/tabpy/tabpy_server/management/state.py
@@ -342,10 +342,8 @@ class TabPyState:
                 dependencies, endpoint_info.get("dependencies", []))
             # Adding is_public means that some existing functions do not have is_public set.
             # We need to check for this when updating and set to False by default
-            current_is_public = False
-            if hasattr(endpoint_info, "is_public"):
-                current_is_public = endpoint_info["is_public"]
-            is_public = self._check_and_set_is_public(is_public, current_is_public)
+            is_public = self._check_and_set_is_public(
+                is_public, getattr(endpoint_info, "is_public", False))
 
             self._check_target(target)
             if target and target not in endpoints:

--- a/tabpy/tabpy_server/management/state.py
+++ b/tabpy/tabpy_server/management/state.py
@@ -340,8 +340,8 @@ class TabPyState:
                 endpoint_type, endpoint_info["type"])
             dependencies = self._check_and_set_dependencies(
                 dependencies, endpoint_info.get("dependencies", []))
-            # Adding is_public means that some existing functions do not have the is_public attribute set. 
-            # We need to check for this when updating and set to False by default 
+            # Adding is_public means that some existing functions do not have is_public set.
+            # We need to check for this when updating and set to False by default
             current_is_public = False
             if hasattr(endpoint_info, "is_public"):
                 current_is_public = endpoint_info["is_public"]

--- a/tabpy/tabpy_server/management/state.py
+++ b/tabpy/tabpy_server/management/state.py
@@ -188,6 +188,7 @@ class TabPyState:
         return dependencies
 
     def _check_and_set_is_public(self, is_public, defaultValue):
+        logger.log(logging.INFO, f"set is_public")
         if is_public is None:
             return defaultValue
 
@@ -340,7 +341,12 @@ class TabPyState:
                 endpoint_type, endpoint_info["type"])
             dependencies = self._check_and_set_dependencies(
                 dependencies, endpoint_info.get("dependencies", []))
-            is_public = self._check_and_set_is_public(is_public, endpoint_info["is_public"])
+            # Adding is_public means that some existing functions do not have the is_public attribute set. 
+            # We need to check for this when updating and set to False by default 
+            current_is_public = False
+            if hasattr(endpoint_info, "is_public"):
+                current_is_public = endpoint_info["is_public"]
+            is_public = self._check_and_set_is_public(is_public, current_is_public)
 
             self._check_target(target)
             if target and target not in endpoints:


### PR DESCRIPTION
update_endpoint_info, and deploy with override set to True were both broken when trying to update a function that had been deployed before is_public existed.

The update code searched for the is_public attribute, and failed when it did not exist. To fix this, when updating a function we first check that is_public exist, and if it does not we default it False if no specific value is set in deploy or update.