### PR TITLE
docs: fix stale file paths in CONTRIBUTING and server-config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ or npm [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli).
 TOC for markdown file is built with [markdown-toc](https://www.npmjs.com/package/markdown-toc):
 
 ```sh
-markdown-toc -i docs/server-startup.md
+markdown-toc -i docs/server-install.md
 ```
 
 To check markdown style for all the documentation use `markdownlint`:
@@ -120,7 +120,7 @@ These checks will run as part of the build if you submit a pull request.
 
 You can invoke the TabPy Server API against a running TabPy instance with Swagger.
 
-- Make CORS related changes in TabPy configuration file: update `tabpy/tabpy-server/state.ini`
+- Make CORS related changes in TabPy configuration file: update `tabpy/tabpy_server/state.ini`
   file in your local repository to have the next settings:
 
 ```config
@@ -130,7 +130,7 @@ Access-Control-Allow-Headers = Origin, X-Requested-with, Content-Type
 Access-Control-Allow-Methods = GET, OPTIONS, POST
 ```
 
-- Start a local instance of TabPy server following [TabPy Server Startup Guide](docs/server-startup.md).
+- Start a local instance of TabPy server following [TabPy Server Startup Guide](docs/server-install.md).
 - Run a local copy of Swagger editor with steps provided at
   [https://github.com/swagger-api/swagger-editor](https://github.com/swagger-api/swagger-editor).
 - Open `misc/TabPy.yml` in Swagger editor.

--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -307,7 +307,7 @@ as explained in Python documentation at
 [Logging Configuration page](https://docs.python.org/3.6/library/logging.config.html).
 
 A default config provided with TabPy is at
-[`tabpy-server/tabpy_server/common/default.conf`](tabpy-server/tabpy_server/common/default.conf)
+[`tabpy/tabpy_server/common/default.conf`](../tabpy/tabpy_server/common/default.conf)
 and has a configuration for console and file loggers. Changing the config file
 allows the user to modify the log level, format of the logged messages and
 add or remove loggers.


### PR DESCRIPTION
Three stale paths, verified against the current tree:

- `CONTRIBUTING.md` references `docs/server-startup.md` twice (markdown-toc command and the "Server Startup Guide" link) — that file doesn't exist; the startup/installation guide is `docs/server-install.md`.
- `CONTRIBUTING.md` tells contributors to update `tabpy/tabpy-server/state.ini` — the directory is `tabpy/tabpy_server` (underscore).
- `docs/server-config.md` links the default config as `tabpy-server/tabpy_server/common/default.conf`, a pre-restructure path that resolves nowhere (doubly so from inside `docs/`); now `../tabpy/tabpy_server/common/default.conf`.

**Verification:** target files confirmed present at the corrected paths; `pytest tests/unit` passes locally (102 passed; Python 3.14, macOS arm64).

Prepared with AI assistance (Claude).